### PR TITLE
Frontend uses username/key for authentication

### DIFF
--- a/Frontend/src/app/modals/user-modal/user-modal.component.html
+++ b/Frontend/src/app/modals/user-modal/user-modal.component.html
@@ -22,21 +22,21 @@
       <div class="modal-body">
         <ng-container *ngIf="mode() === 'login'">
           <input
-            name="email"
+            name="username"
             ngModel
             required
-            type="email"
-            placeholder="Email"
+            type="text"
+            placeholder="Username"
             class="form-input"
-            [(ngModel)]="loginEmail" />
+            [(ngModel)]="loginUsername" />
           <input
-            name="password"
+            name="key"
             ngModel
             required
             type="password"
             placeholder="Password"
             class="form-input"
-            [(ngModel)]="loginPassword" />
+            [(ngModel)]="loginKey" />
         </ng-container>
 
         <ng-container *ngIf="mode() === 'register'">
@@ -49,21 +49,13 @@
             class="form-input"
             [(ngModel)]="regUsername" />
           <input
-            name="email"
-            ngModel
-            required
-            type="email"
-            placeholder="Email"
-            class="form-input"
-            [(ngModel)]="regEmail" />
-          <input
-            name="password"
+            name="key"
             ngModel
             required
             type="password"
             placeholder="Password"
             class="form-input"
-            [(ngModel)]="regPassword" />
+            [(ngModel)]="regKey" />
         </ng-container>
       </div>
 

--- a/Frontend/src/app/modals/user-modal/user-modal.component.ts
+++ b/Frontend/src/app/modals/user-modal/user-modal.component.ts
@@ -3,10 +3,8 @@ import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { UserService } from '../../services/user.service';
-import { ModalService, ModalType } from '../../services/modal.service';
+import { ModalService } from '../../services/modal.service';
 import { StatusService } from '../../services/status.service';
-import {HttpClient} from '@angular/common/http';
-import {firstValueFrom} from 'rxjs';
 
 /**
  * Modal für Login & Registrierung.
@@ -27,17 +25,16 @@ export class UserModalComponent {
   mode = signal<'login' | 'register'>('login');
 
   // login
-  loginEmail = signal('');
-  loginPassword = signal('');
+  loginUsername = signal('');
+  loginKey = signal('');
 
   // register
   regUsername = signal('');
-  regEmail = signal('');
-  regPassword = signal('');
+  regKey = signal('');
 
   async login() {
     try {
-      await this.userService.login(this.loginEmail(), this.loginPassword());
+      await this.userService.login(this.loginUsername(), this.loginKey());
       if (this.userService.isLoggedIn()) {
         this.closeModal();
       }
@@ -50,8 +47,7 @@ export class UserModalComponent {
     try {
       await this.userService.register(
         this.regUsername(),
-        this.regEmail(),
-        this.regPassword()
+        this.regKey()
       );
       if (this.userService.isLoggedIn()) {
         this.closeModal();

--- a/Frontend/src/app/services/user.service.ts
+++ b/Frontend/src/app/services/user.service.ts
@@ -7,13 +7,12 @@ import {Router} from '@angular/router';
 
 interface RegisterRequest {
   username: string;
-  email: string;
-  password: string;
+  key: string;
 }
 
 interface LoginRequest {
-  email: string;
-  password: string;
+  username: string;
+  key: string;
 }
 
 interface AuthResponse {
@@ -68,16 +67,16 @@ export class UserService {
     this.username.set(null);
   }
 
-  async register(username: string, email: string, password: string): Promise<void> {
+  async register(username: string, key: string): Promise<void> {
     const url = `${this.apiBaseUrl}/users`;
-    const payload: RegisterRequest = {username, email, password};
+    const payload: RegisterRequest = {username, key};
     const res = await firstValueFrom(this.http.post<AuthResponse>(url, payload));
     this.setToken(res.token, res.username);
   }
 
-  async login(email: string, password: string): Promise<void> {
+  async login(username: string, key: string): Promise<void> {
     const url = `${this.apiBaseUrl}/users/login`;
-    const payload: LoginRequest = {email, password};
+    const payload: LoginRequest = {username, key};
     const res = await firstValueFrom(this.http.post<AuthResponse>(url, payload));
     this.setToken(res.token, res.username);
     await this.updateUserRole();


### PR DESCRIPTION
## Summary
- refactor user modal and user service for new `key` authentication
- clean up unused code in login/register modal

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684738fda6848322866adc8188f0b9a3