### PR TITLE
Improve responsiveness for navbar and modals

### DIFF
--- a/Frontend/src/app/app.component.css
+++ b/Frontend/src/app/app.component.css
@@ -76,3 +76,38 @@
 .logout-btn:hover {
   /*color: #FF3C3C;*/
 }
+
+#menu-toggle {
+  display: none;
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: #fefde6;
+  font-size: 2rem;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  #navbar {
+    flex-wrap: wrap;
+  }
+  #logo {
+    height: 60px;
+  }
+  #nav-page-container {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+    gap: 10px;
+  }
+  #nav-page-container.open {
+    display: flex;
+  }
+  .link,
+  .bigLink {
+    font-size: 24px;
+  }
+  #menu-toggle {
+    display: block;
+  }
+}

--- a/Frontend/src/app/app.component.html
+++ b/Frontend/src/app/app.component.html
@@ -1,6 +1,7 @@
 <nav id="navbar">
   <img src="assets/images/InconV2png.png" id="logo" alt="Logo">
-  <div id="nav-page-container">
+  <button id="menu-toggle" (click)="toggleMenu()">☰</button>
+  <div id="nav-page-container" [ngClass]="{open: menuOpen}">
     <a class="bigLink" routerLink="home"
        >
       Home

--- a/Frontend/src/app/app.component.ts
+++ b/Frontend/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import {Component, inject, Signal} from '@angular/core';
 import {RouterLink, RouterLinkActive, RouterOutlet} from '@angular/router';
-import {NgIf} from '@angular/common';
+import {NgIf, NgClass} from '@angular/common';
 import {ModalService, ModalType} from './services/modal.service';
 import {OrderCustomDrinkModalComponent} from './modals/order-custom-drink-modal/order-custom-drink-modal.component';
 import {OrderDrinkModalComponent} from './modals/order-drink-modal/order-drink-modal.component';
@@ -15,7 +15,7 @@ import {UserService} from './services/user.service';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, RouterLink, OrderCustomDrinkModalComponent, OrderDrinkModalComponent, AddDrinkModalComponent, EditDrinkModalComponent, BackgroundLeavesComponent, RouterLinkActive, StatusModalComponent, UserModalComponent, NgIf],
+  imports: [RouterOutlet, RouterLink, OrderCustomDrinkModalComponent, OrderDrinkModalComponent, AddDrinkModalComponent, EditDrinkModalComponent, BackgroundLeavesComponent, RouterLinkActive, StatusModalComponent, UserModalComponent, NgIf, NgClass],
   templateUrl: './app.component.html',
   standalone: true,
   styleUrl: './app.component.css'
@@ -28,6 +28,7 @@ export class AppComponent {
 
   title = 'Frontend';
   displayedModal: Signal<ModalType | null> = this.modalService.getDisplayedModal();
+  menuOpen = false;
 
   async ngOnInit() {
     await this.ingredientService.loadIngredients();
@@ -36,6 +37,10 @@ export class AppComponent {
 
   openLoginModal(){
     this.modalService.openModal(ModalType.U,null)
+  }
+
+  toggleMenu() {
+    this.menuOpen = !this.menuOpen;
   }
 
   protected readonly ModalType = ModalType;

--- a/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.css
+++ b/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.css
@@ -81,3 +81,16 @@
 #order-ingredient-add:hover {
   scale: 1.1;
 }
+
+@media (max-width: 768px) {
+  #add-order-ingredient {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+  .order-buttons {
+    flex-direction: column;
+  }
+  #order-ingredient-select {
+    min-width: 120px;
+  }
+}

--- a/Frontend/src/app/modals/user-modal/user-modal.component.css
+++ b/Frontend/src/app/modals/user-modal/user-modal.component.css
@@ -55,3 +55,18 @@ input.form-input {
   display: flex;
   justify-content: center;
 }
+
+.buttons {
+  display: flex;
+  gap: 10px;
+}
+
+@media (max-width: 600px) {
+  input.form-input {
+    width: 100%;
+  }
+  .buttons {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/Frontend/src/styles.css
+++ b/Frontend/src/styles.css
@@ -310,3 +310,11 @@ html{
   font-size: 20px;
   margin: auto 0;
 }
+
+@media (max-width: 600px) {
+  .modal-form {
+    width: 90%;
+    max-width: 90%;
+    padding: 15px;
+  }
+}


### PR DESCRIPTION
## Summary
- add hamburger menu for navigation on small screens
- ensure modals adapt on mobile widths
- stack buttons in the login modal when narrow
- tweak global modal width for phones

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473b83aab88322944db0859db06bf6