### PR TITLE
Add loading indicator for http requests

### DIFF
--- a/Frontend/src/app/app.component.html
+++ b/Frontend/src/app/app.component.html
@@ -64,3 +64,5 @@
   <app-status-modal id="status-modal" [hidden]="displayedModal()!=ModalType.Status"></app-status-modal>
 
 </app-background-leaves>
+
+<app-loading-spinner></app-loading-spinner>

--- a/Frontend/src/app/app.component.ts
+++ b/Frontend/src/app/app.component.ts
@@ -11,10 +11,11 @@ import {DrinkService} from './services/drink.service';
 import {UserModalComponent} from './modals/user-modal/user-modal.component';
 import {UserService} from './services/user.service';
 import {StatusModalComponent} from './modals/status-modal/status-modal.component';
+import {LoadingSpinnerComponent} from './loading-spinner/loading-spinner.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, RouterLink, OrderCustomDrinkModalComponent, OrderDrinkModalComponent, DrinkModalComponent, BackgroundLeavesComponent, RouterLinkActive, UserModalComponent, NgIf, NgClass, StatusModalComponent],
+  imports: [RouterOutlet, RouterLink, OrderCustomDrinkModalComponent, OrderDrinkModalComponent, DrinkModalComponent, BackgroundLeavesComponent, RouterLinkActive, UserModalComponent, NgIf, NgClass, StatusModalComponent, LoadingSpinnerComponent],
   templateUrl: './app.component.html',
   standalone: true,
   styleUrl: './app.component.css'

--- a/Frontend/src/app/app.config.ts
+++ b/Frontend/src/app/app.config.ts
@@ -2,7 +2,8 @@ import {ApplicationConfig, InjectionToken, provideZoneChangeDetection} from '@an
 import {provideRouter, withComponentInputBinding} from '@angular/router';
 
 import { routes } from './app.routes';
-import {provideHttpClient, withFetch} from '@angular/common/http';
+import {provideHttpClient, withFetch, withInterceptors} from '@angular/common/http';
+import {loadingInterceptor} from './services/loading.interceptor';
 
 export const BASE_URL = new InjectionToken<string>('BaseUrl');
 export const WS_URL = new InjectionToken<string>('WsUrl');
@@ -13,7 +14,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes, withComponentInputBinding()),
-    provideHttpClient(withFetch()),
+    provideHttpClient(withFetch(), withInterceptors([loadingInterceptor])),
     { provide: BASE_URL, useValue: `http://${IP}/api/v1` },
     { provide: WS_URL, useValue: `ws://${IP}/ws/orders` },
   ]

--- a/Frontend/src/app/loading-spinner/loading-spinner.component.css
+++ b/Frontend/src/app/loading-spinner/loading-spinner.component.css
@@ -1,0 +1,26 @@
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.spinner {
+  border: 8px solid #f3f3f3;
+  border-top: 8px solid #3498db;
+  border-radius: 50%;
+  width: 60px;
+  height: 60px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/Frontend/src/app/loading-spinner/loading-spinner.component.html
+++ b/Frontend/src/app/loading-spinner/loading-spinner.component.html
@@ -1,0 +1,3 @@
+<div class="loading-overlay" *ngIf="loadingService.isLoading()">
+  <div class="spinner"></div>
+</div>

--- a/Frontend/src/app/loading-spinner/loading-spinner.component.ts
+++ b/Frontend/src/app/loading-spinner/loading-spinner.component.ts
@@ -1,0 +1,14 @@
+import { Component, inject } from '@angular/core';
+import { NgIf } from '@angular/common';
+import { LoadingService } from '../services/loading.service';
+
+@Component({
+  selector: 'app-loading-spinner',
+  standalone: true,
+  imports: [NgIf],
+  templateUrl: './loading-spinner.component.html',
+  styleUrl: './loading-spinner.component.css'
+})
+export class LoadingSpinnerComponent {
+  protected readonly loadingService = inject(LoadingService);
+}

--- a/Frontend/src/app/services/loading.interceptor.ts
+++ b/Frontend/src/app/services/loading.interceptor.ts
@@ -1,0 +1,10 @@
+import { HttpInterceptorFn, HttpRequest, HttpHandlerFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { finalize } from 'rxjs';
+import { LoadingService } from './loading.service';
+
+export const loadingInterceptor: HttpInterceptorFn = (req: HttpRequest<unknown>, next: HttpHandlerFn) => {
+  const service = inject(LoadingService);
+  service.start();
+  return next(req).pipe(finalize(() => service.stop()));
+};

--- a/Frontend/src/app/services/loading.service.ts
+++ b/Frontend/src/app/services/loading.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, signal, computed } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LoadingService {
+  private pending = signal(0);
+  readonly isLoading = computed(() => this.pending() > 0);
+
+  start(): void {
+    this.pending.set(this.pending() + 1);
+  }
+
+  stop(): void {
+    const val = this.pending();
+    if (val > 0) {
+      this.pending.set(val - 1);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create `LoadingService` for global request tracking
- intercept HTTP traffic with `loadingInterceptor`
- show spinner with `LoadingSpinnerComponent`
- register interceptor in `app.config`
- include spinner in the root component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c447db088322b201411db9da12e7