### PR TITLE
Add generic Angular modal service and component

### DIFF
--- a/Backend/HulaSwirl.Api/Drinks/CreateDrink.cs
+++ b/Backend/HulaSwirl.Api/Drinks/CreateDrink.cs
@@ -14,8 +14,7 @@ public static class CreateDrink
         AppDbContext context,
         HttpContext httpContext)
     {
-        if (!httpContext.IsAdmin()) 
-            return Results.Forbid();
+        if (!httpContext.IsAdmin()) return ErrorResults.Forbidden();
 
         return await DrinkFactory.CreateDrinkAsync(context, drinkDto);
     }

--- a/Backend/HulaSwirl.Api/Drinks/DeleteDrink.cs
+++ b/Backend/HulaSwirl.Api/Drinks/DeleteDrink.cs
@@ -11,8 +11,7 @@ public static class DeleteDrink
 {
     public static async Task<IResult> HandleDeleteDrink([FromRoute] int id, AppDbContext context, HttpContext httpContext)
     {
-        if (!httpContext.IsAdmin()) 
-            return Results.Forbid();
+        if (!httpContext.IsAdmin()) return ErrorResults.Forbidden();
 
         var drink = await context.Drink.Include(d => d.DrinkIngredients).FirstOrDefaultAsync(d => d.Id == id);
         if (drink is null) return ErrorResults.NotFound("Drink with id not found");

--- a/Backend/HulaSwirl.Api/Drinks/EditDrink.cs
+++ b/Backend/HulaSwirl.Api/Drinks/EditDrink.cs
@@ -17,7 +17,7 @@ public static class EditDrink
         HttpContext httpContext)
     {
         if (!httpContext.IsAdmin()) 
-            return Results.Forbid();
+            return ErrorResults.Forbidden();
 
         return await DrinkFactory.UpdateDrinkAsync(context, id, drinkDto);
     }

--- a/Backend/HulaSwirl.Api/Orders/CancelOrder.cs
+++ b/Backend/HulaSwirl.Api/Orders/CancelOrder.cs
@@ -15,7 +15,7 @@ public static class CancelOrder
         ObservableOrderService orderService,
         HttpContext httpContext)
     {
-        if (!httpContext.IsAdmin() && !httpContext.IsOperator()) return Results.Forbid();
+        if (!httpContext.IsAdmin() && !httpContext.IsOperator()) return ErrorResults.Forbidden();
 
         var order = await context.Order.FirstOrDefaultAsync(o => o.Id == orderId);
         if (order is null)

--- a/Backend/HulaSwirl.Api/Orders/ConfirmOrder.cs
+++ b/Backend/HulaSwirl.Api/Orders/ConfirmOrder.cs
@@ -24,7 +24,7 @@ public static class ConfirmOrder
         IConfiguration config,
         HttpContext httpContext)
     {
-        if (!httpContext.IsAdmin() && !httpContext.IsOperator()) return Results.Forbid();
+        if (!httpContext.IsAdmin() && !httpContext.IsOperator()) return ErrorResults.Forbidden();
 
         var order = await context.Order
             .Include(o => o.OrderIngredients)

--- a/Backend/HulaSwirl.Api/Orders/GetOrder.cs
+++ b/Backend/HulaSwirl.Api/Orders/GetOrder.cs
@@ -13,7 +13,7 @@ public static class GetOrder
         AppDbContext context,
         HttpContext httpContext)
     {
-        if (!httpContext.IsAdmin() && !httpContext.IsOperator()) return Results.Forbid();
+        if (!httpContext.IsAdmin() && !httpContext.IsOperator()) return ErrorResults.Forbidden();
 
         var order = await context.Order
             .Include(o => o.OrderIngredients)

--- a/Backend/HulaSwirl.Services/UserServices/UserFactory.cs
+++ b/Backend/HulaSwirl.Services/UserServices/UserFactory.cs
@@ -32,7 +32,7 @@ public static class UserFactory
                 Target = "key"
             });
 
-        if (await context.User.AnyAsync(u => u.Username == dto.Username))
+        if (await context.User.AnyAsync(u => u.Username.ToLower() == dto.Username.ToLower()))
             errors.Add(new ErrorDto
             {
                 Message = "A user with this username already exists",

--- a/Frontend/src/app/app.component.css
+++ b/Frontend/src/app/app.component.css
@@ -57,6 +57,7 @@
   color: #FFF5E1;
   font-size: 25px;
   font-family: JosefinSans, sans-serif;
+  cursor: pointer;
 }
 
 #user-section #logout-btn {

--- a/Frontend/src/app/app.component.html
+++ b/Frontend/src/app/app.component.html
@@ -63,6 +63,12 @@
 
   <app-status-modal id="status-modal" [hidden]="displayedModal()!=ModalType.Status"></app-status-modal>
 
+  <ng-container *ngFor="let m of modalStack()">
+    <app-generic-modal *ngIf="m.type === ModalType.Generic" [title]="m.data?.title" [imageUrl]="m.data?.imageUrl" [buttons]="m.data?.buttons">
+      <ng-container *ngIf="m.data?.body" [innerHTML]="m.data.body"></ng-container>
+    </app-generic-modal>
+  </ng-container>
+
 </app-background-leaves>
 
 <app-loading-spinner></app-loading-spinner>

--- a/Frontend/src/app/app.component.html
+++ b/Frontend/src/app/app.component.html
@@ -42,7 +42,7 @@
       <button id="logout-btn" (click)="userService.logout()">Logout</button>
     </ng-container>
     <ng-template #loginRegister>
-      <a class="login-link" (click)="openLoginModal()">Login/Register</a>
+      <a class="login-link" (click)="openLoginModal()">Login</a>
     </ng-template>
   </div>
 
@@ -50,25 +50,11 @@
 
 <app-background-leaves>
   <router-outlet></router-outlet>
-
   <app-order-custom-drink-modal id="order-custom-drink-modal" [hidden]="displayedModal() != ModalType.CustomOrder"></app-order-custom-drink-modal>
-
   <app-order-drink-modal id="order-drink-modal" [hidden]="displayedModal() != ModalType.Order"></app-order-drink-modal>
-
-  <app-drink-modal id="drink-modal"
-                   [hidden]="displayedModal()!=ModalType.AddDrink && displayedModal()!=ModalType.EditDrink"></app-drink-modal>
-
-
+  <app-drink-modal id="drink-modal" [hidden]="displayedModal()!=ModalType.AddDrink && displayedModal()!=ModalType.EditDrink"></app-drink-modal>
   <app-user-modal id="user-modal" [hidden]="displayedModal()!=ModalType.User"></app-user-modal>
-
   <app-status-modal id="status-modal" [hidden]="displayedModal()!=ModalType.Status"></app-status-modal>
-
-  <ng-container *ngFor="let m of modalStack()">
-    <app-generic-modal *ngIf="m.type === ModalType.Generic" [title]="m.data?.title" [imageUrl]="m.data?.imageUrl" [buttons]="m.data?.buttons">
-      <ng-container *ngIf="m.data?.body" [innerHTML]="m.data.body"></ng-container>
-    </app-generic-modal>
-  </ng-container>
-
 </app-background-leaves>
 
 <app-loading-spinner></app-loading-spinner>

--- a/Frontend/src/app/app.component.ts
+++ b/Frontend/src/app/app.component.ts
@@ -5,19 +5,17 @@ import {ModalService, ModalType} from './services/modal.service';
 import {OrderCustomDrinkModalComponent} from './modals/order-custom-drink-modal/order-custom-drink-modal.component';
 import {OrderDrinkModalComponent} from './modals/order-drink-modal/order-drink-modal.component';
 import {DrinkModalComponent} from './modals/drink-modal/drink-modal.component';
-import {BackgroundLeavesComponent} from './background-leaves/background-leaves.component';
 import {IngredientsService} from './services/ingredients.service';
 import {DrinkService} from './services/drink.service';
 import {UserModalComponent} from './modals/user-modal/user-modal.component';
 import {UserService} from './services/user.service';
 import {StatusModalComponent} from './modals/status-modal/status-modal.component';
-import {GenericModalComponent} from './modals/generic-modal/generic-modal.component';
 import {LoadingSpinnerComponent} from './loading-spinner/loading-spinner.component';
-import {LoadingService} from './services/loading.service';
+import {BackgroundLeavesComponent} from './background-leaves/background-leaves.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, RouterLink, OrderCustomDrinkModalComponent, OrderDrinkModalComponent, DrinkModalComponent, BackgroundLeavesComponent, RouterLinkActive, UserModalComponent, NgIf, NgClass, StatusModalComponent, LoadingSpinnerComponent, GenericModalComponent],
+  imports: [RouterOutlet, RouterLink, OrderCustomDrinkModalComponent, OrderDrinkModalComponent, DrinkModalComponent, RouterLinkActive, UserModalComponent, NgIf, NgClass, StatusModalComponent, LoadingSpinnerComponent, BackgroundLeavesComponent],
   templateUrl: './app.component.html',
   standalone: true,
   styleUrl: './app.component.css'
@@ -29,9 +27,7 @@ export class AppComponent {
   private readonly router = inject(Router);
   protected readonly userService = inject(UserService);
 
-  title = 'Frontend';
   displayedModal: Signal<ModalType | null> = this.modalService.getDisplayedModal();
-  modalStack = this.modalService.getModalStack();
   menuOpen = false;
 
   async ngOnInit() {

--- a/Frontend/src/app/app.component.ts
+++ b/Frontend/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import {Component, inject, Signal} from '@angular/core';
-import {RouterLink, RouterLinkActive, RouterOutlet} from '@angular/router';
+import {Router, NavigationStart, RouterLink, RouterLinkActive, RouterOutlet} from '@angular/router';
 import {NgIf, NgClass} from '@angular/common';
 import {ModalService, ModalType} from './services/modal.service';
 import {OrderCustomDrinkModalComponent} from './modals/order-custom-drink-modal/order-custom-drink-modal.component';
@@ -11,12 +11,13 @@ import {DrinkService} from './services/drink.service';
 import {UserModalComponent} from './modals/user-modal/user-modal.component';
 import {UserService} from './services/user.service';
 import {StatusModalComponent} from './modals/status-modal/status-modal.component';
+import {GenericModalComponent} from './modals/generic-modal/generic-modal.component';
 import {LoadingSpinnerComponent} from './loading-spinner/loading-spinner.component';
 import {LoadingService} from './services/loading.service';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, RouterLink, OrderCustomDrinkModalComponent, OrderDrinkModalComponent, DrinkModalComponent, BackgroundLeavesComponent, RouterLinkActive, UserModalComponent, NgIf, NgClass, StatusModalComponent, LoadingSpinnerComponent],
+  imports: [RouterOutlet, RouterLink, OrderCustomDrinkModalComponent, OrderDrinkModalComponent, DrinkModalComponent, BackgroundLeavesComponent, RouterLinkActive, UserModalComponent, NgIf, NgClass, StatusModalComponent, LoadingSpinnerComponent, GenericModalComponent],
   templateUrl: './app.component.html',
   standalone: true,
   styleUrl: './app.component.css'
@@ -25,15 +26,22 @@ export class AppComponent {
   private readonly modalService = inject(ModalService);
   private readonly ingredientService = inject(IngredientsService);
   private readonly drinkService = inject(DrinkService);
+  private readonly router = inject(Router);
   protected readonly userService = inject(UserService);
 
   title = 'Frontend';
   displayedModal: Signal<ModalType | null> = this.modalService.getDisplayedModal();
+  modalStack = this.modalService.getModalStack();
   menuOpen = false;
 
   async ngOnInit() {
     await this.ingredientService.loadIngredients();
     await this.drinkService.loadDrinks();
+    this.router.events.subscribe(event => {
+      if (event instanceof NavigationStart) {
+        this.modalService.closeAll();
+      }
+    });
   }
 
   openLoginModal(){

--- a/Frontend/src/app/home/home.component.html
+++ b/Frontend/src/app/home/home.component.html
@@ -27,6 +27,7 @@
     <div id="button-container">
       <button (click)="scrollToElement()" class="button" id="order-button">ORDER NOW</button>
       <button (click)="openModal(ModalType.CustomOrder)" class="button" id="order-custom-button">ORDER CUSTOM DRINK</button>
+      <button (click)="openInfoModal()" class="button" id="info-button">INFO</button>
     </div>
   </div>
   <img alt="Drink" src="assets/images/DrinkImage.png" id="drink-showcase">

--- a/Frontend/src/app/home/home.component.html
+++ b/Frontend/src/app/home/home.component.html
@@ -27,7 +27,6 @@
     <div id="button-container">
       <button (click)="scrollToElement()" class="button" id="order-button">ORDER NOW</button>
       <button (click)="openModal(ModalType.CustomOrder)" class="button" id="order-custom-button">ORDER CUSTOM DRINK</button>
-      <button (click)="openInfoModal()" class="button" id="info-button">INFO</button>
     </div>
   </div>
   <img alt="Drink" src="assets/images/DrinkImage.png" id="drink-showcase">

--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -1,10 +1,10 @@
-import {Component, effect, ElementRef, inject, Signal, signal, ViewChild, WritableSignal} from '@angular/core';
-import {NgForOf, NgIf, NgOptimizedImage} from '@angular/common';
+import {Component, effect, ElementRef, inject, signal, ViewChild} from '@angular/core';
 import {Ingredient, IngredientsService} from '../services/ingredients.service';
 import {FormsModule} from '@angular/forms';
 import {Drink, DrinkService} from '../services/drink.service';
 import {ModalService, ModalType} from '../services/modal.service';
 import {ErrorService} from '../services/error.service';
+import {NgForOf} from '@angular/common';
 
 @Component({
   selector: 'app-home',

--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -20,7 +20,6 @@ export class HomeComponent {
   private readonly ingredientService = inject(IngredientsService);
   private readonly drinkService = inject(DrinkService);
   private readonly modalService = inject(ModalService);
-  private readonly errorService = inject(ErrorService);
 
   allAvailableDrinks = signal<Drink[]>([]);
   allAvailableIngredients = signal<Ingredient[]>([]);

--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -46,14 +46,6 @@ export class HomeComponent {
     this.modalService.openModal(modal, data);
   }
 
-  openInfoModal() {
-    this.modalService.openGenericModal({
-      title: 'Welcome',
-      body: 'This is a reusable modal example.',
-      buttons: [{ label: 'Close', action: () => this.modalService.closeModal() }]
-    });
-  }
-
   @ViewChild('targetElement', { static: false }) targetElement!: ElementRef;
   scrollToElement() {
     this.targetElement.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'start',alignToTop:true });

--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -46,6 +46,14 @@ export class HomeComponent {
     this.modalService.openModal(modal, data);
   }
 
+  openInfoModal() {
+    this.modalService.openGenericModal({
+      title: 'Welcome',
+      body: 'This is a reusable modal example.',
+      buttons: [{ label: 'Close', action: () => this.modalService.closeModal() }]
+    });
+  }
+
   @ViewChild('targetElement', { static: false }) targetElement!: ElementRef;
   scrollToElement() {
     this.targetElement.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'start',alignToTop:true });

--- a/Frontend/src/app/modals/drink-modal/drink-modal.component.css
+++ b/Frontend/src/app/modals/drink-modal/drink-modal.component.css
@@ -170,7 +170,7 @@ h2 {
   linear-gradient(to bottom right, #ea6b52, #f5d273) border-box;
   border-radius: 10px;
   border: 3px solid transparent;
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   min-height:30px;
   width: 97%;
   height:30px;
@@ -236,7 +236,7 @@ h2 {
   transition: background-color 0.3s ease;
   position: relative;
   background-color: #fdfded;
-  box-shadow: 0px 0px 7px rgba(0, 0, 0, 0.18);
+  box-shadow: 0 0 7px rgba(0, 0, 0, 0.18);
   overflow: hidden;
   height: 200px;
 }

--- a/Frontend/src/app/modals/drink-modal/drink-modal.component.css
+++ b/Frontend/src/app/modals/drink-modal/drink-modal.component.css
@@ -21,16 +21,15 @@
   box-shadow: 0 0 7px rgba(0, 0, 0, 0.05);
 }
 
-.order-buttons {
+.action-buttons {
   display: flex;
   align-items: center;
   justify-content: start;
   gap: 10px;
-  margin-top: 20px;
+  margin-top: 5px;
 }
 
 #drink-available-checkbox {
-  background-color: var(--form-input-bg-yellow);
   padding: 6px 9px;
   display: flex;
   align-items: center;
@@ -52,9 +51,6 @@
   position: relative;
   transition: border-color 0.2s, box-shadow 0.2s;
   cursor: pointer;
-}
-
-#drink-available-checkbox input:checked {
 }
 
 #drink-available-checkbox input:checked::after {
@@ -109,11 +105,10 @@
 #order-ingredient-amount {
   box-sizing: border-box;
   height: 30px;
-  width: 50px;
+  width: 60px;
 }
 
 #order-ingredient-add {
-  background-color: var(--form-input-bg-yellow);
   color: var(--primary-font-color);
   padding: 5px 10px;
   border-radius: 5px;
@@ -127,7 +122,7 @@
   scale: 1.05;
 }
 
-.modal-body {
+[modal-body] {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -148,10 +143,6 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-}
-
-.form-property > .error {
-  margin: 5px 0;
 }
 
 .modal-body {
@@ -193,7 +184,7 @@ h2 {
 }
 
 @media (max-width: 650px) {
-  .modal-body {
+  [modal-body] {
     flex-direction: column-reverse;
     gap: 20px;
   }
@@ -205,6 +196,27 @@ h2 {
   }
   #order-ingredient-add {
     margin-left: 3px;
+  }
+}
+
+@media (max-width: 350px) {
+  .action-buttons {
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  #drink-available-checkbox {
+    order: 1
+  }
+
+  .submit-btn {
+    margin-left: 0;
+    order: 2;
+  }
+
+  .cancel-btn {
+    margin-top: 10px;
+    order: 3;
   }
 }
 
@@ -272,6 +284,8 @@ h2 {
 
 .order-ingredient-amount{
   background-color: #fdfded;
+  box-sizing: border-box;
+  width: 55px;
 }
 
 .order-ingredient-name, .order-new-ingredient-name{

--- a/Frontend/src/app/modals/drink-modal/drink-modal.component.html
+++ b/Frontend/src/app/modals/drink-modal/drink-modal.component.html
@@ -52,7 +52,7 @@
                 <option value="{{ ingredient.ingredientName }}">{{ ingredient.ingredientName }}</option>
               }
             </select>
-            <input type="number" id="order-ingredient-amount" class="form-input" [(ngModel)]="selectedAmount" min="1" step="1" max="500">
+            <input type="number" class="order-ingredient-amount form-input" [(ngModel)]="selectedAmount" min="1" step="1" max="500">
             <span id="order-ingredient-unit">ml</span>
             <span id="order-ingredient-add" class="button" (click)="addIngredient()">+</span>
           </div>
@@ -65,7 +65,7 @@
       <p class="error global-error">{{ globalError() }}</p>
     }
   </div>
-  <div modal-buttons class="order-buttons">
+  <div modal-buttons class="action-buttons">
     @if(mode() === 'edit'){
       <button class="button cancel-btn" (click)="deleteDrink()">Delete</button>
       <div id="drink-available-checkbox" class="button" (click)="drinkAvailable.set(!drinkAvailable())">

--- a/Frontend/src/app/modals/drink-modal/drink-modal.component.html
+++ b/Frontend/src/app/modals/drink-modal/drink-modal.component.html
@@ -1,84 +1,80 @@
-<div class="modal-frame">
-  <div class="modal-form">
-    <div class="modal-head">
-      <h1>{{ mode() === 'add' ? 'Add Drink' : 'Edit Drink' }}</h1>
-      <div class="close-modal-button" (click)="closeModal()"></div>
-    </div>
-    <div class="modal-body">
-      <div id="left-column">
-        <div class="upload-box" [class.drag-over]="isDragging" (click)="fileInput.click()" (dragover)="onDragOver($event)" (dragleave)="onDragLeave($event)" (drop)="onDrop($event)">
-          <span *ngIf="!imageBase64">Upload image</span>
-          <img *ngIf="imageBase64" [src]="imageBase64" alt="Drink image" class="preview-image"/>
-        </div>
-        <input #fileInput type="file" accept="image/*" style="display: none" (change)="onFileSelected($event)"/>
-        <div>
-          <h2 id="toppings-header">Toppings:</h2>
-          <textarea id="drink-toppings" placeholder="No toppings" [(ngModel)]="drinkToppings"></textarea>
-        </div>
+<app-generic-modal [title]="mode() === 'add' ? 'Add Drink' : 'Edit Drink'" (closed)="closeModal()">
+  <div modal-body>
+    <div id="left-column">
+      <div class="upload-box" [class.drag-over]="isDragging" (click)="fileInput.click()" (dragover)="onDragOver($event)" (dragleave)="onDragLeave($event)" (drop)="onDrop($event)">
+        <span *ngIf="!imageBase64">Upload image</span>
+        <img *ngIf="imageBase64" [src]="imageBase64" alt="Drink image" class="preview-image"/>
       </div>
-      <div id="right-column">
-        <div class="form-property">
-          <input id="drink-title" placeholder="Title" [(ngModel)]="drinkTitle" (input)="clearFieldError('name')">
-          <p class="error field-error">{{drinkTitleError()}}</p>
-        </div>
-        <div class="form-property">
-          <h2>Ingredients:</h2>
-          <p class="error field-error">{{drinkIngredientsError()}}</p>
-          <div id="drink-ingredients">
-            @for(ingredient of drinkIngredients(); track $index){
-              <div class="order-ingredient">
-                <div class="order-ingredient-details">
-                  <div class="ingredient-properties">
-                    @if(ingredient.type=='new'){
-                      <input class="order-new-ingredient-name" [(ngModel)]="ingredient.ingredientName">
-                    } @else {
-                      <span class="order-new-ingredient">{{ ingredient.ingredientName }}</span>
-                    }
-                    <input min="1" max="100" type="number" class="order-ingredient-amount form-input" [(ngModel)]="ingredient.amount" (input)="clearFieldError(ingredient.ingredientName)">
-                    <span class="order-ingredient-unit">ml</span>
-                  </div>
-                  <span class="order-ingredient-delete" (click)="deleteIngredient($index)">❌</span>
+      <input #fileInput type="file" accept="image/*" style="display: none" (change)="onFileSelected($event)"/>
+      <div>
+        <h2 id="toppings-header">Toppings:</h2>
+        <textarea id="drink-toppings" placeholder="No toppings" [(ngModel)]="drinkToppings"></textarea>
+      </div>
+    </div>
+    <div id="right-column">
+      <div class="form-property">
+        <input id="drink-title" placeholder="Title" [(ngModel)]="drinkTitle" (input)="clearFieldError('name')">
+        <p class="error field-error">{{drinkTitleError()}}</p>
+      </div>
+      <div class="form-property">
+        <h2>Ingredients:</h2>
+        <p class="error field-error">{{drinkIngredientsError()}}</p>
+        <div id="drink-ingredients">
+          @for(ingredient of drinkIngredients(); track $index){
+            <div class="order-ingredient">
+              <div class="order-ingredient-details">
+                <div class="ingredient-properties">
+                  @if(ingredient.type=='new'){
+                    <input class="order-new-ingredient-name" [(ngModel)]="ingredient.ingredientName">
+                  } @else {
+                    <span class="order-new-ingredient">{{ ingredient.ingredientName }}</span>
+                  }
+                  <input min="1" max="100" type="number" class="order-ingredient-amount form-input" [(ngModel)]="ingredient.amount" (input)="clearFieldError(ingredient.ingredientName)">
+                  <span class="order-ingredient-unit">ml</span>
                 </div>
-                <p class="error field-error">{{ingredient.status}}</p>
+                <span class="order-ingredient-delete" (click)="deleteIngredient($index)">❌</span>
               </div>
-            } @empty {
-              <div class="order-ingredient">
-                <div class="order-ingredient-details">
-                  <div class="ingredient-properties">
-                    <span class="order-ingredient-name">No ingredients added</span>
-                  </div>
-                </div>
-              </div>
-            }
-            <div id="add-new-ingredient">
-              <select id="order-ingredient-select" class="form-input" [(ngModel)]="selectedIngredient">
-                <option value="newIngredient">New Ingredient</option>
-                @for(ingredient of availableIngredients(); track $index){
-                  <option value="{{ ingredient.ingredientName }}">{{ ingredient.ingredientName }}</option>
-                }
-              </select>
-              <input type="number" id="order-ingredient-amount" class="form-input" [(ngModel)]="selectedAmount" min="1" step="1" max="500">
-              <span id="order-ingredient-unit">ml</span>
-              <span id="order-ingredient-add" class="button" (click)="addIngredient()">+</span>
+              <p class="error field-error">{{ingredient.status}}</p>
             </div>
+          } @empty {
+            <div class="order-ingredient">
+              <div class="order-ingredient-details">
+                <div class="ingredient-properties">
+                  <span class="order-ingredient-name">No ingredients added</span>
+                </div>
+              </div>
+            </div>
+          }
+          <div id="add-new-ingredient">
+            <select id="order-ingredient-select" class="form-input" [(ngModel)]="selectedIngredient">
+              <option value="newIngredient">New Ingredient</option>
+              @for(ingredient of availableIngredients(); track $index){
+                <option value="{{ ingredient.ingredientName }}">{{ ingredient.ingredientName }}</option>
+              }
+            </select>
+            <input type="number" id="order-ingredient-amount" class="form-input" [(ngModel)]="selectedAmount" min="1" step="1" max="500">
+            <span id="order-ingredient-unit">ml</span>
+            <span id="order-ingredient-add" class="button" (click)="addIngredient()">+</span>
           </div>
         </div>
       </div>
     </div>
+  </div>
+  <div modal-footer>
     @if(globalError()){
       <p class="error global-error">{{ globalError() }}</p>
     }
-    <div class="order-buttons">
-      @if(mode() === 'edit'){
-        <button class="button cancel-btn" (click)="deleteDrink()">Delete</button>
-        <div id="drink-available-checkbox" class="button" (click)="drinkAvailable.set(!drinkAvailable())">
-          <input type="checkbox" [(ngModel)]="drinkAvailable">
-          <label>
-            Available
-          </label>
-        </div>
-      }
-      <button class="button submit-btn" (click)="submitDrink()">{{ mode() === 'add' ? 'Add' : 'Update' }}</button>
-    </div>
   </div>
-</div>
+  <div modal-buttons class="order-buttons">
+    @if(mode() === 'edit'){
+      <button class="button cancel-btn" (click)="deleteDrink()">Delete</button>
+      <div id="drink-available-checkbox" class="button" (click)="drinkAvailable.set(!drinkAvailable())">
+        <input type="checkbox" [(ngModel)]="drinkAvailable">
+        <label>
+          Available
+        </label>
+      </div>
+    }
+    <button class="button submit-btn" (click)="submitDrink()">{{ mode() === 'add' ? 'Add' : 'Update' }}</button>
+  </div>
+</app-generic-modal>

--- a/Frontend/src/app/modals/drink-modal/drink-modal.component.ts
+++ b/Frontend/src/app/modals/drink-modal/drink-modal.component.ts
@@ -7,12 +7,13 @@ import {
 } from '../../services/ingredients.service';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
+import {GenericModalComponent} from '../generic-modal/generic-modal.component';
 import { Drink, DrinkBase, DrinkService } from '../../services/drink.service';
 import { ErrorHandlingComponent } from '../../services/error-handling';
 
 @Component({
   selector: 'app-drink-modal',
-  imports: [FormsModule, CommonModule],
+  imports: [FormsModule, CommonModule, GenericModalComponent],
   templateUrl: './drink-modal.component.html',
   standalone: true,
   styleUrls: ['./drink-modal.component.css'],

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.css
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.css
@@ -1,0 +1,6 @@
+/* Generic modal specific tweaks if needed */
+.modal-image {
+  max-width: 100%;
+  display: block;
+  margin-bottom: 10px;
+}

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.css
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.css
@@ -1,6 +1,78 @@
-/* Generic modal specific tweaks if needed */
-.modal-image {
-  max-width: 100%;
-  display: block;
-  margin-bottom: 10px;
+/* Modal */
+.modal-frame {
+  position: fixed;
+  z-index: 100;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  backdrop-filter: blur(1px);
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal-form {
+  background-color: var(--popup-bg);
+  border-radius: 10px;
+  padding: 20px;
+  max-width: 550px;
+  width: 80%;
+  box-shadow: 0 0 10px 3px rgb(64, 64, 64);
+}
+
+.modal-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  color: var(--primary-font-color);
+}
+
+.modal-head h1 {
+  margin: 0;
+}
+
+.close-modal-button {
+  font-size: 24px;
+  font-weight: bold;
+  height: 20px;
+  width: 20px;
+  text-align: center;
+  line-height: 24px;
+  transition: 0.3s transform ease;
+  margin: -7px -7px 0 0;
+}
+.close-modal-button:after{
+  content: '✖';
+}
+.close-modal-button:hover {
+  cursor: pointer;
+  transform: rotate(10deg);
+}
+
+.modal-body {
+  margin: 15px 0;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+}
+
+@media screen and (max-width: 650px) {
+  .modal-body {
+    max-height: 400px;
+  }
+}
+
+@media (max-width: 350px) {
+  .modal-form {
+    width: 85%;
+    padding: 15px;
+  }
 }

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.html
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.html
@@ -1,0 +1,15 @@
+<div class="modal-frame">
+  <div class="modal-form">
+    <div class="modal-head">
+      <h1>{{ title }}</h1>
+      <span class="close-modal-button" (click)="close()"></span>
+    </div>
+    <div class="modal-body">
+      <img *ngIf="imageUrl" [src]="imageUrl" class="modal-image" />
+      <ng-content></ng-content>
+    </div>
+    <div class="modal-footer" *ngIf="buttons.length > 0">
+      <button *ngFor="let btn of buttons" class="button" (click)="btn.action()">{{ btn.label }}</button>
+    </div>
+  </div>
+</div>

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.html
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.html
@@ -6,9 +6,13 @@
     </div>
     <div class="modal-body">
       <img *ngIf="imageUrl" [src]="imageUrl" class="modal-image" />
-      <ng-content></ng-content>
+      <ng-content select="[modal-body]"></ng-content>
     </div>
-    <div class="modal-footer" *ngIf="buttons.length > 0">
+    <div class="modal-footer">
+      <ng-content select="[modal-footer]"></ng-content>
+    </div>
+    <div class="modal-buttons">
+      <ng-content select="[modal-buttons]"></ng-content>
       <button *ngFor="let btn of buttons" class="button" (click)="btn.action()">{{ btn.label }}</button>
     </div>
   </div>

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.html
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.html
@@ -5,7 +5,6 @@
       <span class="close-modal-button" (click)="close()"></span>
     </div>
     <div class="modal-body">
-      <img *ngIf="imageUrl" [src]="imageUrl" class="modal-image" />
       <ng-content select="[modal-body]"></ng-content>
     </div>
     <div class="modal-footer">

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.ts
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.ts
@@ -16,7 +16,7 @@ export interface GenericModalButton {
 })
 export class GenericModalComponent {
   @Input() title: string = '';
-  @Input() imageUrl: string | null = null;
+  //@Input() imageUrl: string | null = null;
   @Input() buttons: GenericModalButton[] = [];
   @Output() closed = new EventEmitter<void>();
 

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.ts
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.ts
@@ -1,0 +1,27 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ModalService } from '../../services/modal.service';
+
+export interface GenericModalButton {
+  label: string;
+  action: () => void;
+}
+
+@Component({
+  selector: 'app-generic-modal',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './generic-modal.component.html',
+  styleUrls: ['./generic-modal.component.css']
+})
+export class GenericModalComponent {
+  @Input() title: string = '';
+  @Input() imageUrl: string | null = null;
+  @Input() buttons: GenericModalButton[] = [];
+
+  constructor(private modalService: ModalService) {}
+
+  close() {
+    this.modalService.closeModal();
+  }
+}

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.ts
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalService } from '../../services/modal.service';
 
@@ -18,10 +18,12 @@ export class GenericModalComponent {
   @Input() title: string = '';
   @Input() imageUrl: string | null = null;
   @Input() buttons: GenericModalButton[] = [];
+  @Output() closed = new EventEmitter<void>();
 
   constructor(private modalService: ModalService) {}
 
   close() {
+    this.closed.emit();
     this.modalService.closeModal();
   }
 }

--- a/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.html
+++ b/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.html
@@ -1,39 +1,30 @@
-<div class="modal-frame">
-  <div class="modal-form">
-      <div class="modal-head">
-        <h1>Configure your own Drink</h1>
-        <span class="close-modal-button" (click)="closeModal()"></span>
+<app-generic-modal title="Configure your own Drink" (closed)="closeModal()">
+  <div modal-body id="ingredient-list">
+    @for(ingredient of availableIngredients(); track $index){
+      <div class="order-ingredient" [class.selected]="isSelected(ingredient.ingredientName)" (click)="toggleIngredient(ingredient, $event.target!)">
+        <input type="checkbox" class="ingredient-check" tabindex="0" [checked]="isSelected(ingredient.ingredientName)">
+        <div class="order-ingredient-details">
+          <div class="ingredient-properties">
+            <span class="order-ingredient-name">{{ ingredient.ingredientName }}</span>
+            <input min="1" max="500" type="number" class="order-ingredient-amount form-input" (click)="toggleIngredient(ingredient, $event.target!)" [attr.tabindex]="$index + 1" [ngModel]="getAmount(ingredient.ingredientName)" (ngModelChange)="updateAmount(ingredient.ingredientName, $event)">
+            <span class="order-ingredient-unit">ml</span>
+          </div>
+          <p class="error field-error">{{ getStatus(ingredient.ingredientName) }}</p>
+        </div>
       </div>
-      <div class="modal-body" id="ingredient-list">
-        @for(ingredient of availableIngredients(); track $index){
-          <div class="order-ingredient" [class.selected]="isSelected(ingredient.ingredientName)" (click)="toggleIngredient(ingredient, $event.target!)">
-            <input type="checkbox" class="ingredient-check" tabindex="0"
-                   [checked]="isSelected(ingredient.ingredientName)">
-            <div class="order-ingredient-details">
-              <div class="ingredient-properties">
-                <span class="order-ingredient-name">{{ ingredient.ingredientName }}</span>
-                <input min="1" max="500" type="number" class="order-ingredient-amount form-input"
-                       (click)="toggleIngredient(ingredient, $event.target!)"
-                       [attr.tabindex]="$index + 1"
-                       [ngModel]="getAmount(ingredient.ingredientName)"
-                       (ngModelChange)="updateAmount(ingredient.ingredientName, $event)">
-                <span class="order-ingredient-unit">ml</span>
-              </div>
-              <p class="error field-error">{{ getStatus(ingredient.ingredientName) }}</p>
-            </div>
-          </div>
-        } @empty {
-          <div id="no-ingredients">
-            <span class="order-ingredient-name">No ingredients available</span>
-          </div>
-        }
-    </div>
+    } @empty {
+      <div id="no-ingredients">
+        <span class="order-ingredient-name">No ingredients available</span>
+      </div>
+    }
+  </div>
+  <div modal-footer>
     @if(globalError()) {
       <p class="error global-error">{{ globalError() }}</p>
     }
-      <div class="order-buttons">
-        <button class="button cancel-btn" (click)="closeModal()">Cancel</button>
-        <button class="button submit-btn" (click)="submitOrder()">Order</button>
-      </div>
   </div>
-</div>
+  <div modal-buttons class="order-buttons">
+    <button class="button cancel-btn" (click)="closeModal()">Cancel</button>
+    <button class="button submit-btn" (click)="submitOrder()">Order</button>
+  </div>
+</app-generic-modal>

--- a/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.ts
+++ b/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.ts
@@ -3,12 +3,11 @@ import {FormsModule} from '@angular/forms';
 import {Ingredient, IngredientsService, OrderPreparation} from '../../services/ingredients.service';
 import {ModalService, ModalType} from '../../services/modal.service';
 import {ErrorHandlingComponent} from '../../services/error-handling';
-import {NgForOf} from '@angular/common';
 import {GenericModalComponent} from '../generic-modal/generic-modal.component';
 
 @Component({
   selector: 'app-order-custom-drink-modal',
-  imports: [FormsModule, GenericModalComponent, NgForOf],
+  imports: [FormsModule, GenericModalComponent],
   templateUrl: './order-custom-drink-modal.component.html',
   standalone: true,
   styleUrl: './order-custom-drink-modal.component.css'

--- a/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.ts
+++ b/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.ts
@@ -4,10 +4,11 @@ import {Ingredient, IngredientsService, OrderPreparation} from '../../services/i
 import {ModalService, ModalType} from '../../services/modal.service';
 import {ErrorHandlingComponent} from '../../services/error-handling';
 import {NgForOf} from '@angular/common';
+import {GenericModalComponent} from '../generic-modal/generic-modal.component';
 
 @Component({
   selector: 'app-order-custom-drink-modal',
-  imports: [FormsModule],
+  imports: [FormsModule, GenericModalComponent, NgForOf],
   templateUrl: './order-custom-drink-modal.component.html',
   standalone: true,
   styleUrl: './order-custom-drink-modal.component.css'

--- a/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.ts
+++ b/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.ts
@@ -1,7 +1,7 @@
 import {Component, effect, inject, signal, WritableSignal} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {Ingredient, IngredientsService, OrderPreparation} from '../../services/ingredients.service';
-import {ModalService, ModalType} from '../../services/modal.service';
+import {ModalService} from '../../services/modal.service';
 import {ErrorHandlingComponent} from '../../services/error-handling';
 import {GenericModalComponent} from '../generic-modal/generic-modal.component';
 

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.css
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.css
@@ -1,17 +1,15 @@
-.modal-body {
+#drink-overview {
   display: flex;
   gap: 20px;
-  color: var(--primary-font-color);
-  overflow: hidden;
+  margin-bottom: 10px;
 }
 
-@media screen and (max-width: 600px) {
-  .modal-body {
+@media screen and (max-width: 650px) {
+  #drink-overview {
     flex-direction: column;
     max-height: 100%;
   }
-
-  .modal-body .modal-image {
+  .modal-image {
     align-self: center;
   }
 }
@@ -40,17 +38,19 @@ p:not(.error) {
   overflow-wrap: break-word;
 }
 
-.modal-body .modal-image {
+.modal-image {
+  width: 260px;
+  height: 260px;
+  box-sizing: border-box;
+  overflow: hidden;
+  border-radius: 10px;
+  border: 2px dashed var(--element-primary-outline);
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 265px;
-  height: 265px;
-  overflow: hidden;
-  border-radius: 10px;
 }
 
-.modal-body .modal-image img {
+.modal-image img {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -102,4 +102,9 @@ ul li:nth-child(6n+5)::before {
 
 ul li:nth-child(6n+6)::before {
   content: "🦩";
+}
+
+[modal-buttons] {
+  display: flex;
+  justify-content: end;
 }

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
@@ -1,29 +1,25 @@
-<div class="modal-frame">
-  <div class="modal-form">
-    <div class="modal-head">
-      <h1>{{selectedDrink()?.name}}</h1>
-      <span class="close-modal-button" (click)="closeModal()"></span>
+<app-generic-modal [title]="selectedDrink()?.name" (closed)="closeModal()">
+  <div modal-body>
+    <div class="modal-image">
+      <img [src]="selectedDrink()?.imgUrl" alt="Drink Image" class="drink-image" />
     </div>
-    <div class="modal-body">
-      <div class="modal-image">
-        <img [src]="selectedDrink()?.imgUrl" alt="Drink Image" class="drink-image">
-      </div>
-      <div id="modal-ingredient-list">
-        <h3>Ingredients:</h3>
-        <ul>
-          <li *ngFor="let drink of selectedDrink()?.drinkIngredients">{{drink.amount}}ml {{drink.ingredientName}}</li>
-        </ul>
-      </div>
+    <div id="modal-ingredient-list">
+      <h3>Ingredients:</h3>
+      <ul>
+        <li *ngFor="let drink of selectedDrink()?.drinkIngredients">{{drink.amount}}ml {{drink.ingredientName}}</li>
+      </ul>
     </div>
-    <div class="modal-footer">
-      <div id="toppings">
-        <h4>Toppings:</h4>
-        <p>{{selectedDrink()?.toppings}}</p>
-      </div>
-      <button class="button submit-btn" (click)="submitOrder()">Order</button>
+  </div>
+  <div modal-footer>
+    <div id="toppings">
+      <h4>Toppings:</h4>
+      <p>{{selectedDrink()?.toppings}}</p>
     </div>
     @if (globalError()){
       <p class="error global-error">{{ globalError() }}</p>
     }
   </div>
-</div>
+  <div modal-buttons>
+    <button class="button submit-btn" (click)="submitOrder()">Order</button>
+  </div>
+</app-generic-modal>

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
@@ -1,23 +1,27 @@
-<app-generic-modal [title]="selectedDrink()?.name" (closed)="closeModal()">
+<app-generic-modal title="{{selectedDrink()?.name}}" (closed)="closeModal()">
   <div modal-body>
-    <div class="modal-image">
-      <img [src]="selectedDrink()?.imgUrl" alt="Drink Image" class="drink-image" />
+    <div id="drink-overview">
+      <div class="modal-image">
+        @if (selectedDrink()?.imgUrl) {
+          <img [src]="selectedDrink()?.imgUrl" alt="Drink Image" class="drink-image" />
+        } @else {
+          <p>No image available</p>
+        }
+      </div>
+      <div id="modal-ingredient-list">
+        <h3>Ingredients:</h3>
+        <ul>
+          <li *ngFor="let drink of selectedDrink()?.drinkIngredients">{{drink.amount}}ml {{drink.ingredientName}}</li>
+        </ul>
+      </div>
     </div>
-    <div id="modal-ingredient-list">
-      <h3>Ingredients:</h3>
-      <ul>
-        <li *ngFor="let drink of selectedDrink()?.drinkIngredients">{{drink.amount}}ml {{drink.ingredientName}}</li>
-      </ul>
-    </div>
-  </div>
-  <div modal-footer>
     <div id="toppings">
       <h4>Toppings:</h4>
       <p>{{selectedDrink()?.toppings}}</p>
     </div>
-    @if (globalError()){
-      <p class="error global-error">{{ globalError() }}</p>
-    }
+  </div>
+  <div modal-footer>
+    <p class="error global-error">{{ globalError() }}</p>
   </div>
   <div modal-buttons>
     <button class="button submit-btn" (click)="submitOrder()">Order</button>

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.ts
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.ts
@@ -1,5 +1,6 @@
 import {Component, inject, signal, Signal, WritableSignal} from '@angular/core';
 import {NgForOf} from "@angular/common";
+import {GenericModalComponent} from '../generic-modal/generic-modal.component';
 import {Drink, DrinkService} from '../../services/drink.service';
 import {ModalService, ModalType} from '../../services/modal.service';
 import {ErrorHandlingComponent} from '../../services/error-handling';
@@ -7,7 +8,8 @@ import {ErrorHandlingComponent} from '../../services/error-handling';
 @Component({
   selector: 'app-order-drink-modal',
   imports: [
-    NgForOf
+    NgForOf,
+    GenericModalComponent
   ],
   templateUrl: './order-drink-modal.component.html',
   standalone: true,

--- a/Frontend/src/app/modals/status-modal/status-modal.component.html
+++ b/Frontend/src/app/modals/status-modal/status-modal.component.html
@@ -1,13 +1,11 @@
-<div class="modal-frame">
-  <div class="modal-form">
-    <div class="modal-head">
-      <h1>Status</h1>
-    </div>
-    <!-- Fortschrittsbalken -->
+<app-generic-modal title="Status" (closed)="closeModal()">
+  <div modal-body>
     <div *ngIf="progressVisible" class="progress-container">
       <div class="progress-bar" [style.width.%]="progress"></div>
     </div>
     <p id="statusMessage">{{statusMessage()}}</p>
+  </div>
+  <div modal-buttons>
     <div class="button submit-btn" (click)="closeModal()">OK</div>
   </div>
-</div>
+</app-generic-modal>

--- a/Frontend/src/app/modals/status-modal/status-modal.component.ts
+++ b/Frontend/src/app/modals/status-modal/status-modal.component.ts
@@ -67,6 +67,6 @@ export class StatusModalComponent {
     this.progressVisible = false;
     this.progress = 0;
     this.statusMessage.set('');
-    this.modalService.closeModal();
+    this.modalService.closeAll();
   }
 }

--- a/Frontend/src/app/modals/status-modal/status-modal.component.ts
+++ b/Frontend/src/app/modals/status-modal/status-modal.component.ts
@@ -1,4 +1,4 @@
-import {Component, effect, inject, signal, WritableSignal} from '@angular/core';
+import {Component, effect, inject, signal, Signal} from '@angular/core';
 import {ModalService, ModalType} from '../../services/modal.service';
 import { NgIf } from '@angular/common';
 import {Drink} from '../../services/drink.service';
@@ -16,7 +16,7 @@ export class StatusModalComponent {
   statusMessage = signal('');
   progress: number = 0;
   progressVisible: boolean = false;
-  currentModalData: WritableSignal<any>=signal(null);
+  currentModalData: Signal<any> = signal(null);
 
   async ngOnInit() {
     this.currentModalData = this.modalService.getModalData();

--- a/Frontend/src/app/modals/status-modal/status-modal.component.ts
+++ b/Frontend/src/app/modals/status-modal/status-modal.component.ts
@@ -1,12 +1,13 @@
 import {Component, effect, inject, signal, Signal} from '@angular/core';
 import {ModalService, ModalType} from '../../services/modal.service';
 import { NgIf } from '@angular/common';
+import {GenericModalComponent} from '../generic-modal/generic-modal.component';
 import {Drink} from '../../services/drink.service';
 
 @Component({
   selector: 'app-status-modal',
   standalone: true,
-  imports: [NgIf],
+  imports: [NgIf, GenericModalComponent],
   templateUrl: './status-modal.component.html',
   styleUrl: './status-modal.component.css'
 })

--- a/Frontend/src/app/modals/status-modal/status-modal.component.ts
+++ b/Frontend/src/app/modals/status-modal/status-modal.component.ts
@@ -2,7 +2,6 @@ import {Component, effect, inject, signal, Signal} from '@angular/core';
 import {ModalService, ModalType} from '../../services/modal.service';
 import { NgIf } from '@angular/common';
 import {GenericModalComponent} from '../generic-modal/generic-modal.component';
-import {Drink} from '../../services/drink.service';
 
 @Component({
   selector: 'app-status-modal',

--- a/Frontend/src/app/modals/user-modal/user-modal.component.css
+++ b/Frontend/src/app/modals/user-modal/user-modal.component.css
@@ -45,20 +45,23 @@ input.form-input {
 
 }
 
-.modal-body{
+[modal-body]{
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.modal-footer{
-  display: flex;
-  justify-content: center;
+a {
+  color: var(--link-color);
+  text-decoration: underline;
+  cursor: pointer;
 }
 
 .buttons {
+  justify-content: center;
   display: flex;
   gap: 10px;
+
 }
 
 .field-error {

--- a/Frontend/src/app/modals/user-modal/user-modal.component.html
+++ b/Frontend/src/app/modals/user-modal/user-modal.component.html
@@ -1,29 +1,28 @@
 <app-generic-modal [title]="mode() === 'login' ? 'Login' : 'Register'" (closed)="closeModal()">
-  <form modal-body (ngSubmit)="onSubmit()" #authForm="ngForm">
-    <div class="tab-switch centered">
-      <button type="button" [class.active]="mode() === 'login'" (click)="switchMode('login')">Login</button>
-      <button type="button" [class.active]="mode() === 'register'" (click)="switchMode('register')">Register</button>
-    </div>
+  <form (ngSubmit)="onSubmit()" modal-body #authForm="ngForm">
     <ng-container *ngIf="mode() === 'login'">
       <input name="username" ngModel required type="text" placeholder="Username" class="form-input" (input)="clearFieldError('username')" [(ngModel)]="loginUsername" />
       <p class="error field-error" *ngIf="fieldErrors()['username']">{{ fieldErrors()['username'] }}</p>
       <input name="key" ngModel required type="password" placeholder="Key" class="form-input" (input)="clearFieldError('key')" [(ngModel)]="loginKey" />
       <p class="error field-error" *ngIf="fieldErrors()['key']">{{ fieldErrors()['key'] }}</p>
+      <small>Don't have an account yet? <a (click)="switchMode('register')">Register</a></small>
     </ng-container>
     <ng-container *ngIf="mode() === 'register'">
       <input name="username" ngModel required type="text" placeholder="Username" class="form-input" (input)="clearFieldError('username')" [(ngModel)]="regUsername" />
       <p class="error field-error" *ngIf="fieldErrors()['username']">{{ fieldErrors()['username'] }}</p>
       <input name="key" ngModel required type="password" placeholder="Key" class="form-input" (input)="clearFieldError('key')" [(ngModel)]="regKey" />
       <p class="error field-error" *ngIf="fieldErrors()['key']">{{ fieldErrors()['key'] }}</p>
+      <small>Already have an account? <a (click)="switchMode('login')">Login</a></small>
     </ng-container>
-    <div modal-footer>
-      <div class="error" *ngIf="globalError().length">
-        <p *ngFor="let err of globalError()">{{ err }}</p>
-      </div>
-    </div>
-    <div modal-buttons class="buttons">
-      <button type="submit" class="button submit-btn" [disabled]="authForm.invalid">{{ mode() === 'login' ? 'Login' : 'Register' }}</button>
-      <button type="button" class="button cancel-btn" (click)="closeModal()">Cancel</button>
-    </div>
+    <button type="submit" [disabled]="authForm.invalid" hidden></button>
   </form>
+  <div modal-footer>
+    <div class="error" *ngIf="globalError().length">
+      <p *ngFor="let err of globalError()">{{ err }}</p>
+    </div>
+  </div>
+  <div modal-buttons class="buttons">
+    <button type="submit" class="button submit-btn" (click)="onSubmit()" [disabled]="authForm.invalid">{{ mode() === 'login' ? 'Login' : 'Register' }}</button>
+    <button type="button" class="button cancel-btn" (click)="closeModal()">Cancel</button>
+  </div>
 </app-generic-modal>

--- a/Frontend/src/app/modals/user-modal/user-modal.component.html
+++ b/Frontend/src/app/modals/user-modal/user-modal.component.html
@@ -1,93 +1,29 @@
-<div class="modal-frame">
-  <div class="modal-form">
-    <form (ngSubmit)="onSubmit()" #authForm="ngForm">
-      <div class="modal-head flex-row">
-        <div class="tab-switch centered">
-          <button
-            type="button"
-            [class.active]="mode() === 'login'"
-            (click)="switchMode('login')">
-            Login
-          </button>
-          <button
-            type="button"
-            [class.active]="mode() === 'register'"
-            (click)="switchMode('register')">
-            Register
-          </button>
-        </div>
-        <span class="close-modal-button right" (click)="closeModal()"></span>
+<app-generic-modal [title]="mode() === 'login' ? 'Login' : 'Register'" (closed)="closeModal()">
+  <form modal-body (ngSubmit)="onSubmit()" #authForm="ngForm">
+    <div class="tab-switch centered">
+      <button type="button" [class.active]="mode() === 'login'" (click)="switchMode('login')">Login</button>
+      <button type="button" [class.active]="mode() === 'register'" (click)="switchMode('register')">Register</button>
+    </div>
+    <ng-container *ngIf="mode() === 'login'">
+      <input name="username" ngModel required type="text" placeholder="Username" class="form-input" (input)="clearFieldError('username')" [(ngModel)]="loginUsername" />
+      <p class="error field-error" *ngIf="fieldErrors()['username']">{{ fieldErrors()['username'] }}</p>
+      <input name="key" ngModel required type="password" placeholder="Key" class="form-input" (input)="clearFieldError('key')" [(ngModel)]="loginKey" />
+      <p class="error field-error" *ngIf="fieldErrors()['key']">{{ fieldErrors()['key'] }}</p>
+    </ng-container>
+    <ng-container *ngIf="mode() === 'register'">
+      <input name="username" ngModel required type="text" placeholder="Username" class="form-input" (input)="clearFieldError('username')" [(ngModel)]="regUsername" />
+      <p class="error field-error" *ngIf="fieldErrors()['username']">{{ fieldErrors()['username'] }}</p>
+      <input name="key" ngModel required type="password" placeholder="Key" class="form-input" (input)="clearFieldError('key')" [(ngModel)]="regKey" />
+      <p class="error field-error" *ngIf="fieldErrors()['key']">{{ fieldErrors()['key'] }}</p>
+    </ng-container>
+    <div modal-footer>
+      <div class="error" *ngIf="globalError().length">
+        <p *ngFor="let err of globalError()">{{ err }}</p>
       </div>
-
-      <div class="modal-body">
-        <ng-container *ngIf="mode() === 'login'">
-          <input
-            name="username"
-            ngModel
-            required
-            type="text"
-            placeholder="Username"
-            class="form-input"
-            (input)="clearFieldError('username')"
-            [(ngModel)]="loginUsername" />
-          <p class="error field-error" *ngIf="fieldErrors()['username']">{{ fieldErrors()['username'] }}</p>
-          <input
-            name="key"
-            ngModel
-            required
-            type="password"
-            placeholder="Key"
-            class="form-input"
-            (input)="clearFieldError('key')"
-            [(ngModel)]="loginKey" />
-          <p class="error field-error" *ngIf="fieldErrors()['key']">{{ fieldErrors()['key'] }}</p>
-        </ng-container>
-
-        <ng-container *ngIf="mode() === 'register'">
-          <input
-            name="username"
-            ngModel
-            required
-            type="text"
-            placeholder="Username"
-            class="form-input"
-            (input)="clearFieldError('username')"
-            [(ngModel)]="regUsername" />
-          <p class="error field-error" *ngIf="fieldErrors()['username']">{{ fieldErrors()['username'] }}</p>
-          <input
-            name="key"
-            ngModel
-            required
-            type="password"
-            placeholder="Key"
-            class="form-input"
-            (input)="clearFieldError('key')"
-            [(ngModel)]="regKey" />
-          <p class="error field-error" *ngIf="fieldErrors()['key']">{{ fieldErrors()['key'] }}</p>
-        </ng-container>
-      </div>
-
-      <div class="modal-footer">
-        <div class="error" *ngIf="globalError().length">
-          <p *ngFor="let err of globalError()">{{ err }}</p>
-        </div>
-        <div class="buttons">
-          <!-- Submit-Button löst onSubmit() per Enter oder Klick aus -->
-          <button
-            type="submit"
-            class="button submit-btn"
-            [disabled]="authForm.invalid">
-            {{ mode() === 'login' ? 'Login' : 'Register' }}
-          </button>
-          <!-- Abbrechen bleibt type="button" -->
-          <button
-            type="button"
-            class="button cancel-btn"
-            (click)="closeModal()">
-            Cancel
-          </button>
-        </div>
-      </div>
-    </form>
-  </div>
-</div>
+    </div>
+    <div modal-buttons class="buttons">
+      <button type="submit" class="button submit-btn" [disabled]="authForm.invalid">{{ mode() === 'login' ? 'Login' : 'Register' }}</button>
+      <button type="button" class="button cancel-btn" (click)="closeModal()">Cancel</button>
+    </div>
+  </form>
+</app-generic-modal>

--- a/Frontend/src/app/modals/user-modal/user-modal.component.ts
+++ b/Frontend/src/app/modals/user-modal/user-modal.component.ts
@@ -6,6 +6,7 @@ import {GenericModalComponent} from '../generic-modal/generic-modal.component';
 import { UserService } from '../../services/user.service';
 import { ModalService } from '../../services/modal.service';
 import { ErrorHandlingComponent } from '../../services/error-handling';
+import {RouterLink} from '@angular/router';
 
 /**
  * Modal für Login & Registrierung.

--- a/Frontend/src/app/modals/user-modal/user-modal.component.ts
+++ b/Frontend/src/app/modals/user-modal/user-modal.component.ts
@@ -6,7 +6,6 @@ import {GenericModalComponent} from '../generic-modal/generic-modal.component';
 import { UserService } from '../../services/user.service';
 import { ModalService } from '../../services/modal.service';
 import { ErrorHandlingComponent } from '../../services/error-handling';
-import {RouterLink} from '@angular/router';
 
 /**
  * Modal für Login & Registrierung.

--- a/Frontend/src/app/modals/user-modal/user-modal.component.ts
+++ b/Frontend/src/app/modals/user-modal/user-modal.component.ts
@@ -2,6 +2,7 @@
 import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import {GenericModalComponent} from '../generic-modal/generic-modal.component';
 import { UserService } from '../../services/user.service';
 import { ModalService } from '../../services/modal.service';
 import { ErrorHandlingComponent } from '../../services/error-handling';
@@ -13,7 +14,7 @@ import { ErrorHandlingComponent } from '../../services/error-handling';
 @Component({
   selector: 'app-user-modal',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, GenericModalComponent],
   templateUrl: './user-modal.component.html',
   styleUrls: ['./user-modal.component.css']
 })

--- a/Frontend/src/app/order-terminal/order-terminal.component.html
+++ b/Frontend/src/app/order-terminal/order-terminal.component.html
@@ -1,4 +1,3 @@
-<div class="error" *ngIf="globalErrors().length"><p *ngFor="let err of globalErrors()">{{ err }}</p></div>
 <div class="orders" *ngIf="orders().length; else noOrders">
   <div class="order-card" *ngFor="let o of orders()">
     <h3>{{ o.drinkName }}</h3>

--- a/Frontend/src/app/order-terminal/order-terminal.component.ts
+++ b/Frontend/src/app/order-terminal/order-terminal.component.ts
@@ -24,7 +24,6 @@ import {ErrorHandlingComponent} from '../services/error-handling';
 export class OrderTerminalComponent extends ErrorHandlingComponent {
   private readonly ordersService = inject(OrdersService);
   private readonly statusService = inject(ErrorService);
-  globalErrors = signal<string>("");
   public orders: WritableSignal<IncomingOrder[]> = this.ordersService.orders;
 
   ngOnInit(): void {

--- a/Frontend/src/app/order-terminal/order-terminal.component.ts
+++ b/Frontend/src/app/order-terminal/order-terminal.component.ts
@@ -1,10 +1,7 @@
-import {Component, inject, signal, WritableSignal} from '@angular/core';
-import {HttpClient} from '@angular/common/http';
+import {Component, inject, WritableSignal} from '@angular/core';
 import {IncomingOrder, OrdersService} from '../services/orders.service';
 import { firstValueFrom } from 'rxjs';
 import {DatePipe, NgForOf, NgIf} from '@angular/common';
-import {UserService} from '../services/user.service';
-import {BASE_URL} from '../app.config';
 import {ErrorService} from '../services/error.service';
 import {ErrorHandlingComponent} from '../services/error-handling';
 

--- a/Frontend/src/app/services/error.service.ts
+++ b/Frontend/src/app/services/error.service.ts
@@ -14,7 +14,15 @@ export class ErrorService {
     setGlobalError: (message: string) => void
   ): void {
     if (e instanceof HttpErrorResponse) {
+      if( e.status === 401) {
+        this.showMessage('You need to log in to perform this action.');
+        return;
+      }
       const payload = e.error;
+      if (e.status === 403) {
+        this.showMessage(payload[0].message);
+        return;
+      }
       const errors = Array.isArray(payload) ? payload : [payload];
       for (const err of errors) {
         if (err && typeof err === 'object' && 'message' in err) {

--- a/Frontend/src/app/services/error.service.ts
+++ b/Frontend/src/app/services/error.service.ts
@@ -32,7 +32,7 @@ export class ErrorService {
           } else {
             setGlobalError(em.message);
           }
-        } else if (typeof err === 'string') {
+        } else {
           setGlobalError(err);
         }
       }

--- a/Frontend/src/app/services/modal.service.ts
+++ b/Frontend/src/app/services/modal.service.ts
@@ -1,11 +1,12 @@
-import {effect, EventEmitter, Injectable, Output, signal, WritableSignal} from '@angular/core';
+import {effect, computed, Injectable, signal, WritableSignal} from '@angular/core';
 export enum ModalType{
   CustomOrder,
   Order,
   AddDrink,
   EditDrink,
   Status,
-  User
+  User,
+  Generic
 }
 @Injectable({
   providedIn: 'root'
@@ -14,28 +15,59 @@ export class ModalService {
 
   constructor() {
     effect(() => {
-      document.body.style.overflow = this.displayedModal() !== null ? 'hidden' : '';
+      document.body.style.overflow = this.modalStack().length > 0 ? 'hidden' : '';
     });
   }
 
-  private displayedModal: WritableSignal<null|ModalType> = signal(null);
-  private modalData: WritableSignal<any> = signal(null);
+  private modalStack: WritableSignal<{type: ModalType; data: any; persist: boolean;}[]> = signal([]);
+  private persistedData: Record<ModalType, any> = {} as Record<ModalType, any>;
 
-  closeModal() {
-    this.modalData.set(null);
-    this.displayedModal.set(null);
+  closeModal(keepData: boolean = false) {
+    const stack = [...this.modalStack()];
+    const modal = stack.pop();
+    if (modal) {
+      if (modal.persist && !keepData) {
+        this.persistedData[modal.type] = modal.data;
+      } else if (!modal.persist) {
+        delete this.persistedData[modal.type];
+      }
+    }
+    this.modalStack.set(stack);
   }
 
-  openModal(modal: ModalType, data: any ) {
-    this.modalData.set(data);
-    this.displayedModal.set(modal);
+  closeAll() {
+    this.modalStack.set([]);
+    this.persistedData = {} as Record<ModalType, any>;
+  }
+
+  openModal(modal: ModalType, data: any = null, persist: boolean = false) {
+    if (data === null && this.persistedData[modal]) {
+      data = this.persistedData[modal];
+    }
+    const stack = [...this.modalStack()];
+    stack.push({ type: modal, data, persist });
+    this.modalStack.set(stack);
+  }
+
+  openGenericModal(config: any, persist: boolean = false) {
+    this.openModal(ModalType.Generic, config, persist);
+  }
+
+  getModalStack() {
+    return this.modalStack;
   }
 
   getDisplayedModal() {
-    return this.displayedModal;
+    return computed(() => {
+      const stack = this.modalStack();
+      return stack.length > 0 ? stack[stack.length - 1].type : null;
+    });
   }
 
   getModalData() {
-    return this.modalData;
+    return computed(() => {
+      const stack = this.modalStack();
+      return stack.length > 0 ? stack[stack.length - 1].data : null;
+    });
   }
 }

--- a/Frontend/src/app/services/modal.service.ts
+++ b/Frontend/src/app/services/modal.service.ts
@@ -45,12 +45,11 @@ export class ModalService {
       data = this.persistedData[modal];
     }
     const stack = [...this.modalStack()];
-    stack.push({ type: modal, data, persist });
-    this.modalStack.set(stack);
-  }
-
-  openGenericModal(config: any, persist: boolean = false) {
-    this.openModal(ModalType.Generic, config, persist);
+    const existingIndex = stack.findIndex(m => m.type === modal);
+    if (existingIndex == -1) {
+      stack.push({type: modal, data, persist});
+      this.modalStack.set(stack);
+    }
   }
 
   getModalStack() {

--- a/Frontend/src/styles.css
+++ b/Frontend/src/styles.css
@@ -226,6 +226,13 @@ html{
   gap: 20px;
 }
 
+.modal-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 20px;
+}
+
 /* Drink filter */
 .drink-filter-container {
   max-width: 1200px;

--- a/Frontend/src/styles.css
+++ b/Frontend/src/styles.css
@@ -1,7 +1,7 @@
 :root {
   --body-bg: #faeee1;
   --popup-bg: #f4e3cd;
-  --container-bg-color: #9dc2d5;
+  --link-color: #6091af;
   --ingredient-bg-color: #f4f3f2;
   --ingredient-quantity-bg-color: #f1e1c3;
   --ingredient-selected-bg-color: #eeffe4;
@@ -14,7 +14,6 @@
   --sunrise-gradient: linear-gradient(to bottom right, #f65a5a 0%, #ffd15e 100%);
   --primary-font-color: #575757;
   --heavy-font-color: #3f3f3f;
-  --form-input-bg: #f4f3f2;
   --form-input-bg-yellow: #fdfded;
 
   --default-font: 'JosefinSans';
@@ -107,7 +106,7 @@ html{
 }
 
 .button:hover {
-  scale: calc(1.05);
+  scale: 1.05;
 }
 
 .cancel-btn {
@@ -122,7 +121,7 @@ html{
 }
 
 .form-input {
-  background-color: var(--form-input-bg);
+  background-color: var(--form-input-bg-yellow);
   border: 1px solid var(--element-primary-outline);
   border-radius: 5px;
   padding: 5px 10px;
@@ -158,79 +157,6 @@ html{
 
 ::-webkit-scrollbar-thumb:hover {
   background: #c43a3a;
-}
-
-/* Modal */
-.modal-frame {
-  position: fixed;
-  z-index: 100;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  backdrop-filter: blur(1px);
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.modal-form {
-  background-color: var(--popup-bg);
-  border-radius: 10px;
-  padding: 20px;
-  max-width: 550px;
-  width: 80%;
-  box-shadow: 0 0 10px 3px rgb(64, 64, 64);
-}
-
-.modal-head {
-  display: flex;
-  justify-content: space-between;
-  gap: 20px;
-  color: var(--primary-font-color);
-}
-
-.modal-head h1 {
-  margin: 0;
-}
-
-.close-modal-button {
-  font-size: 24px;
-  font-weight: bold;
-  height: 20px;
-  width: 20px;
-  text-align: center;
-  line-height: 24px;
-  transition: 0.3s transform ease;
-  margin: -7px -7px 0 0;
-}
-.close-modal-button:after{
-  content: '✖';
-}
-.close-modal-button:hover {
-  cursor: pointer;
-  transform: rotate(10deg);
-}
-
-.modal-body {
-  margin: 20px 0;
-  max-height: 300px;
-  overflow-y: auto;
-}
-
-.modal-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 20px;
-}
-
-.modal-buttons {
-  display: flex;
-  justify-content: center;
-  gap: 10px;
-  margin-top: 20px;
 }
 
 /* Drink filter */
@@ -288,7 +214,7 @@ html{
   overflow: hidden;
   background: linear-gradient(#F6F6F6, #F6F6F6) padding-box,
   linear-gradient(to bottom right, #ea6b52 , #f5d273) border-box;
-  border-radius: 20px;
+  border-radius: 15px;
   border: 4px solid transparent;
   filter: drop-shadow(0px 0px 10px rgba(68, 47, 36, 0.25)) saturate(110%);
   padding: 0;
@@ -325,24 +251,16 @@ html{
 }
 
 .error {
+  margin: 0;
   color: red !important;
   font-weight: lighter !important;
 }
 
 .field-error {
-  margin: 0;
   font-size: 14px !important;
 }
 
 .global-error {
   font-size: 16px !important;
-  margin-top: 1rem !important;
-}
-
-@media (max-width: 600px) {
-  .modal-form {
-    width: 90%;
-    max-width: 90%;
-    padding: 15px;
-  }
+  margin: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- introduce a stacked modal service with data persistence
- add a standalone `GenericModalComponent`
- close all modals on route changes
- demonstrate the new modal on home page

## Testing
- `npm ci`
- `npx ng test --watch=false` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6857e9f543308322bfd242b48ff08591