### PR TITLE
Add glass visual for order card

### DIFF
--- a/Frontend/src/app/order-terminal/order-terminal.component.css
+++ b/Frontend/src/app/order-terminal/order-terminal.component.css
@@ -74,3 +74,55 @@
   color: #666;
   margin: 2rem 0;
 }
+
+/* New glass layout */
+.order-content {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.glass-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.glass {
+  width: 120px;
+  height: 240px;
+  border: 3px solid #555;
+  border-radius: 0 0 15px 15px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column-reverse;
+  background: #fff;
+}
+
+.layer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #000;
+  font-size: 0.7rem;
+  text-align: center;
+  padding: 2px;
+}
+
+.total {
+  margin-top: 0.25rem;
+  font-size: 0.9rem;
+  font-weight: bold;
+}
+
+.ingredient-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  flex: 1;
+}
+
+.ingredient-list li {
+  margin-bottom: 0.25rem;
+}

--- a/Frontend/src/app/order-terminal/order-terminal.component.html
+++ b/Frontend/src/app/order-terminal/order-terminal.component.html
@@ -5,11 +5,23 @@
       By <strong>{{ o.user }}</strong> –
       <small>{{ o.orderDate | date:'short' }}</small>
     </p>
-    <ul>
-      <li *ngFor="let i of o.orderIngredients">
-        {{ i.ingredientName }} – {{ i.amount }} ml
-      </li>
-    </ul>
+    <div class="order-content">
+      <div class="glass-wrapper">
+        <div class="glass">
+          <div class="layer" *ngFor="let i of o.orderIngredients"
+               [style.background]="getIngredientColor(i.ingredientName)"
+               [style.height.%]="getHeight(i.amount)">
+            <span class="layer-text">{{ i.ingredientName }} – {{ i.amount }} ml</span>
+          </div>
+        </div>
+        <p class="total">{{ getTotal(o.orderIngredients) }} / 500 ml</p>
+      </div>
+      <ul class="ingredient-list">
+        <li *ngFor="let i of o.orderIngredients">
+          {{ i.ingredientName }} – {{ i.amount }} ml
+        </li>
+      </ul>
+    </div>
     <div class="actions">
       <button  (click)="confirm(o.id)">Mix</button>
       <button  (click)="cancel(o.id)">Discard</button>

--- a/Frontend/src/app/order-terminal/order-terminal.component.ts
+++ b/Frontend/src/app/order-terminal/order-terminal.component.ts
@@ -26,6 +26,20 @@ export class OrderTerminalComponent extends ErrorHandlingComponent {
   ngOnInit(): void {
     this.connectWebSocket();
   }
+
+  getIngredientColor(name: string): string {
+    const hash = Array.from(name).reduce((acc, c) => acc + c.charCodeAt(0), 0);
+    const hue = hash % 360;
+    return `hsl(${hue}, 70%, 60%)`;
+  }
+
+  getHeight(amount: number): number {
+    return Math.min(amount / 500 * 100, 100);
+  }
+
+  getTotal(ings: { amount: number }[]): number {
+    return ings.reduce((sum, i) => sum + i.amount, 0);
+  }
   connectWebSocket(): void {
     this.ordersService.connectWebSocket()
   }


### PR DESCRIPTION
## Summary
- improve design of order terminal order card
- add functions for computing ingredient colors and sizes
- show a glass filled with colored layers for each ingredient
- style the new glass layout

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a422453048322b92021942220eb55