### PR TITLE
Implement real‑time user updates

### DIFF
--- a/Backend/HulaSwirl.Api/Program.cs
+++ b/Backend/HulaSwirl.Api/Program.cs
@@ -8,6 +8,8 @@ using HulaSwirl.Services.DataAccess;
 using HulaSwirl.Services.OrderService;
 using HulaSwirl.Services.Pumps;
 using HulaSwirl.Services.UserServices;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
@@ -42,6 +44,7 @@ builder.Services.AddCors(options =>
 //custom services
 builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
 builder.Services.AddSingleton<ObservableOrderService>();
+builder.Services.AddSingleton<ObservableUserService>();
 builder.Services.AddSingleton<JwtService>();
 builder.Services.AddSingleton<PumpManager>();
 builder.Services.AddSingleton<GpioController>();
@@ -70,6 +73,37 @@ builder.Services.AddAuthentication(options =>
             ValidateLifetime = false,
             ValidateIssuerSigningKey = true,
             IssuerSigningKey = new SymmetricSecurityKey(key)
+        };
+
+        options.Events = new JwtBearerEvents
+        {
+            OnTokenValidated = async context =>
+            {
+                var db = context.HttpContext.RequestServices.GetRequiredService<AppDbContext>();
+                var username = context.Principal?.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Sub)?.Value;
+                if (string.IsNullOrWhiteSpace(username))
+                {
+                    context.Fail("Username missing");
+                    return;
+                }
+
+                var user = await db.User.FindAsync(username);
+                if (user is null)
+                {
+                    context.Fail("User not found");
+                    return;
+                }
+
+                var identity = context.Principal!.Identity as ClaimsIdentity;
+                if (identity != null)
+                {
+                    foreach (var roleClaim in identity.FindAll(ClaimTypes.Role).ToList())
+                        identity.RemoveClaim(roleClaim);
+                    identity.AddClaim(new Claim(ClaimTypes.Role, user.Role));
+                    if (!identity.HasClaim(c => c.Type == ClaimTypes.Name))
+                        identity.AddClaim(new Claim(ClaimTypes.Name, user.Username));
+                }
+            }
         };
     });
 builder.Services.AddAuthorization();

--- a/Backend/HulaSwirl.Api/Users/DeleteUser.cs
+++ b/Backend/HulaSwirl.Api/Users/DeleteUser.cs
@@ -10,6 +10,7 @@ public static class DeleteUser
     public static async Task<IResult> HandleDelete(
         [FromRoute] string username,
         AppDbContext db,
+        ObservableUserService userObservable,
         HttpContext http)
     {
         if (!http.IsAdmin()) return ErrorResults.Forbidden();
@@ -22,6 +23,7 @@ public static class DeleteUser
         
         db.User.Remove(user);
         await db.SaveChangesAsync();
+        await userObservable.BroadcastAsync(new UserUpdate { Username = username, Type = "deleted" });
         return Results.NoContent();
     }
 }

--- a/Backend/HulaSwirl.Api/Users/UpdateUserRole.cs
+++ b/Backend/HulaSwirl.Api/Users/UpdateUserRole.cs
@@ -12,6 +12,7 @@ public static class UpdateUserRole
         [FromRoute] string username,
         [FromQuery] string role,
         AppDbContext db,
+        ObservableUserService userObservable,
         HttpContext http)
     {
         var isSystem = http.IsSystem();
@@ -32,6 +33,7 @@ public static class UpdateUserRole
         user.Role = role.ToLower();
         db.User.Update(user);
         await db.SaveChangesAsync();
+        await userObservable.BroadcastAsync(new UserUpdate { Username = user.Username, Role = user.Role, Type = "role" });
         return Results.Ok();
     }
 }

--- a/Backend/HulaSwirl.Api/Users/UserApi.cs
+++ b/Backend/HulaSwirl.Api/Users/UserApi.cs
@@ -6,6 +6,7 @@ public static class UserApi
 
     public static IEndpointRouteBuilder MapUserApi(this IEndpointRouteBuilder app)
     {
+        app.Map("ws/user-updates", UserUpdates.HandleUserUpdates);
         // 1) User erstellen
         app.MapPost(baseUrl, CreateUser.HandleCreate)
             .WithName(nameof(CreateUser.HandleCreate))

--- a/Backend/HulaSwirl.Api/Users/UserUpdates.cs
+++ b/Backend/HulaSwirl.Api/Users/UserUpdates.cs
@@ -1,0 +1,59 @@
+using System.Net.WebSockets;
+using HulaSwirl.Services.DataAccess;
+using HulaSwirl.Services.UserServices;
+
+namespace HulaSwirl.Api.Users;
+
+public static class UserUpdates
+{
+    public static async Task HandleUserUpdates(
+        HttpContext context,
+        ObservableUserService userObservable,
+        JwtService jwtService,
+        AppDbContext db)
+    {
+        if (!context.WebSockets.IsWebSocketRequest)
+        {
+            context.Response.StatusCode = 400;
+            return;
+        }
+
+        var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(authHeader) || !authHeader.StartsWith("Bearer "))
+        {
+            context.Response.StatusCode = 401;
+            return;
+        }
+
+        string username;
+        try
+        {
+            username = jwtService.GetUsernameFromToken(authHeader);
+        }
+        catch
+        {
+            context.Response.StatusCode = 401;
+            return;
+        }
+
+        var user = await db.User.FindAsync(username);
+        if (user is null)
+        {
+            context.Response.StatusCode = 401;
+            return;
+        }
+
+        var socket = await context.WebSockets.AcceptWebSocketAsync();
+        var observer = new UserWebSocketObserver(socket);
+        var subscription = userObservable.Subscribe(observer);
+
+        var buffer = new byte[1024 * 4];
+        while (socket.State == WebSocketState.Open)
+        {
+            var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+            if (result.MessageType == WebSocketMessageType.Close)
+                break;
+        }
+        subscription.Dispose();
+    }
+}

--- a/Backend/HulaSwirl.Services/UserServices/JwtService.cs
+++ b/Backend/HulaSwirl.Services/UserServices/JwtService.cs
@@ -22,6 +22,7 @@ public class JwtService
     {
         var claims = new[] {
             new Claim(JwtRegisteredClaimNames.Sub, user.Username),
+            new Claim(ClaimTypes.Name, user.Username),
             new Claim(ClaimTypes.Role, user.Role)
         };
 
@@ -29,6 +30,7 @@ public class JwtService
         var token = new JwtSecurityToken(
             issuer: _config["Jwt:Issuer"],
             audience: _config["Jwt:Audience"],
+            expires: DateTime.UtcNow.AddHours(1),
             claims: claims,
             signingCredentials: creds);
 

--- a/Backend/HulaSwirl.Services/UserServices/ObservableUserService.cs
+++ b/Backend/HulaSwirl.Services/UserServices/ObservableUserService.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace HulaSwirl.Services.UserServices;
+
+public class ObservableUserService : IObservable<UserUpdate>
+{
+    private readonly List<IObserver<UserUpdate>> _observers = [];
+
+    public IDisposable Subscribe(IObserver<UserUpdate> observer)
+    {
+        if (!_observers.Contains(observer))
+            _observers.Add(observer);
+        return new Unsubscriber(_observers, observer);
+    }
+
+    public async Task BroadcastAsync(UserUpdate update)
+    {
+        foreach (var observer in _observers.ToArray())
+        {
+            observer.OnNext(update);
+        }
+        await Task.CompletedTask;
+    }
+
+    private class Unsubscriber : IDisposable
+    {
+        private readonly List<IObserver<UserUpdate>> _observers;
+        private readonly IObserver<UserUpdate>? _observer;
+
+        public Unsubscriber(List<IObserver<UserUpdate>> observers, IObserver<UserUpdate> observer)
+        {
+            _observers = observers;
+            _observer = observer;
+        }
+
+        public void Dispose()
+        {
+            if (_observer != null && _observers.Contains(_observer))
+                _observers.Remove(_observer);
+        }
+    }
+}

--- a/Backend/HulaSwirl.Services/UserServices/UserUpdate.cs
+++ b/Backend/HulaSwirl.Services/UserServices/UserUpdate.cs
@@ -1,0 +1,8 @@
+namespace HulaSwirl.Services.UserServices;
+
+public class UserUpdate
+{
+    public required string Username { get; set; }
+    public required string Type { get; set; } // "deleted" or "role"
+    public string? Role { get; set; }
+}

--- a/Backend/HulaSwirl.Services/UserServices/UserWebSocketObserver.cs
+++ b/Backend/HulaSwirl.Services/UserServices/UserWebSocketObserver.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace HulaSwirl.Services.UserServices;
+
+public class UserWebSocketObserver(WebSocket webSocket) : IObserver<UserUpdate>
+{
+    public void OnCompleted() { }
+    public void OnError(Exception error) { }
+
+    public void OnNext(UserUpdate update)
+    {
+        if (webSocket.State != WebSocketState.Open) return;
+        var json = JsonSerializer.Serialize(update, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var buffer = Encoding.UTF8.GetBytes(json);
+        webSocket.SendAsync(buffer, WebSocketMessageType.Text, true, CancellationToken.None).GetAwaiter().GetResult();
+    }
+}

--- a/Frontend/src/app/app.config.ts
+++ b/Frontend/src/app/app.config.ts
@@ -7,6 +7,7 @@ import {loadingInterceptor} from './services/loading.interceptor';
 
 export const BASE_URL = new InjectionToken<string>('BaseUrl');
 export const WS_URL = new InjectionToken<string>('WsUrl');
+export const USER_WS_URL = new InjectionToken<string>('UserWsUrl');
 const IP = "192.168.0.200:8080";
 //const IP = "localhost:5110";
 
@@ -17,5 +18,6 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(withFetch(), withInterceptors([loadingInterceptor])),
     { provide: BASE_URL, useValue: `http://${IP}/api/v1` },
     { provide: WS_URL, useValue: `ws://${IP}/ws/orders` },
+    { provide: USER_WS_URL, useValue: `ws://${IP}/ws/user-updates` },
   ]
 };

--- a/Frontend/src/app/services/user.service.ts
+++ b/Frontend/src/app/services/user.service.ts
@@ -2,7 +2,7 @@ import {effect, inject, Injectable, signal} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {firstValueFrom} from 'rxjs';
 import {ErrorService} from './error.service';
-import {BASE_URL} from '../app.config';
+import {BASE_URL, USER_WS_URL} from '../app.config';
 import {Router} from '@angular/router';
 
 interface RegisterRequest {
@@ -18,6 +18,12 @@ interface LoginRequest {
 interface AuthResponse {
   token: string;
   username: string;
+}
+
+interface UserUpdate {
+  username: string;
+  type: string;
+  role?: string;
 }
 
 export interface AccountInfo {
@@ -41,6 +47,8 @@ export class UserService {
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
   private apiBaseUrl = inject(BASE_URL);
+  private userWsUrl = inject(USER_WS_URL);
+  private userWs?: WebSocket;
 
   jwt = signal<string | null>(this.getTokenFromStorage());
   username = signal<string | null>(this.getUsernameFromStorage());
@@ -52,6 +60,30 @@ export class UserService {
     effect(async () => {
       await this.updateUserRole();
     });
+    if (this.isLoggedIn()) {
+      this.connectWebSocket();
+    }
+  }
+
+  private connectWebSocket() {
+    if (this.userWs) {
+      this.userWs.close();
+    }
+    this.userWs = new WebSocket(this.userWsUrl);
+    this.userWs.onmessage = async evt => {
+      const update: UserUpdate = JSON.parse(evt.data);
+      if (update.username !== this.username()) return;
+      if (update.type === 'deleted') {
+        await this.logout();
+      } else if (update.type === 'role') {
+        await this.updateUserRole();
+      }
+    };
+  }
+
+  private disconnectWebSocket() {
+    this.userWs?.close();
+    this.userWs = undefined;
   }
 
   public getTokenFromStorage(): string | null {
@@ -87,6 +119,7 @@ export class UserService {
     const payload: RegisterRequest = {username, key};
     const res = await firstValueFrom(this.http.post<AuthResponse>(url, payload));
     this.setToken(res.token, res.username);
+    this.connectWebSocket();
   }
 
   async login(username: string, key: string): Promise<void> {
@@ -94,10 +127,12 @@ export class UserService {
     const payload: LoginRequest = {username, key};
     const res = await firstValueFrom(this.http.post<AuthResponse>(url, payload));
     this.setToken(res.token, res.username);
+    this.connectWebSocket();
     await this.updateUserRole();
   }
 
   async logout() {
+    this.disconnectWebSocket();
     this.clearToken();
     await this.updateUserRole();
     await this.router.navigate(['/home']);


### PR DESCRIPTION
## Summary
- enable token role refresh on every request
- broadcast user updates via WebSockets
- connect to user update socket in frontend
- add injection token for user update socket URL

## Testing
- `npm install`
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_685d9008a39883228788232085798b6d