### PR TITLE
Add websocket user events and token checks

### DIFF
--- a/Backend/HulaSwirl.Api/Program.cs
+++ b/Backend/HulaSwirl.Api/Program.cs
@@ -11,6 +11,7 @@ using HulaSwirl.Services.UserServices;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using System.Security.Claims;
 
 var solutionRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
 var builder = WebApplication.CreateBuilder(new WebApplicationOptions
@@ -42,6 +43,7 @@ builder.Services.AddCors(options =>
 //custom services
 builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
 builder.Services.AddSingleton<ObservableOrderService>();
+builder.Services.AddSingleton<ObservableUserService>();
 builder.Services.AddSingleton<JwtService>();
 builder.Services.AddSingleton<PumpManager>();
 builder.Services.AddSingleton<GpioController>();
@@ -67,9 +69,34 @@ builder.Services.AddAuthentication(options =>
         {
             ValidateIssuer = false,
             ValidateAudience = false,
-            ValidateLifetime = false,
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.Zero,
             ValidateIssuerSigningKey = true,
             IssuerSigningKey = new SymmetricSecurityKey(key)
+        };
+        options.Events = new JwtBearerEvents
+        {
+            OnTokenValidated = async context =>
+            {
+                var db = context.HttpContext.RequestServices.GetRequiredService<AppDbContext>();
+                var username = context.Principal?.FindFirst(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub)?.Value;
+                if (string.IsNullOrEmpty(username))
+                {
+                    context.Fail("Invalid token");
+                    return;
+                }
+                var user = await db.User.FindAsync(username);
+                if (user == null)
+                {
+                    context.Fail("User deleted");
+                    return;
+                }
+                var identity = context.Principal!.Identity as ClaimsIdentity;
+                var roleClaim = identity!.FindFirst(ClaimTypes.Role);
+                if (roleClaim != null)
+                    identity.RemoveClaim(roleClaim);
+                identity.AddClaim(new Claim(ClaimTypes.Role, user.Role));
+            }
         };
     });
 builder.Services.AddAuthorization();

--- a/Backend/HulaSwirl.Api/Users/DeleteUser.cs
+++ b/Backend/HulaSwirl.Api/Users/DeleteUser.cs
@@ -10,7 +10,8 @@ public static class DeleteUser
     public static async Task<IResult> HandleDelete(
         [FromRoute] string username,
         AppDbContext db,
-        HttpContext http)
+        HttpContext http,
+        ObservableUserService userService)
     {
         if (!http.IsAdmin()) return ErrorResults.Forbidden();
         var user = await db.User.FindAsync(username);
@@ -22,6 +23,7 @@ public static class DeleteUser
         
         db.User.Remove(user);
         await db.SaveChangesAsync();
+        await userService.BroadcastAsync(username, new UserEvent { EventType = "deleted" });
         return Results.NoContent();
     }
 }

--- a/Backend/HulaSwirl.Api/Users/UpdateUserRole.cs
+++ b/Backend/HulaSwirl.Api/Users/UpdateUserRole.cs
@@ -12,7 +12,8 @@ public static class UpdateUserRole
         [FromRoute] string username,
         [FromQuery] string role,
         AppDbContext db,
-        HttpContext http)
+        HttpContext http,
+        ObservableUserService userService)
     {
         var isSystem = http.IsSystem();
         var isAdmin = http.IsAdmin();
@@ -32,6 +33,7 @@ public static class UpdateUserRole
         user.Role = role.ToLower();
         db.User.Update(user);
         await db.SaveChangesAsync();
+        await userService.BroadcastAsync(username, new UserEvent { EventType = "role-changed", Role = user.Role });
         return Results.Ok();
     }
 }

--- a/Backend/HulaSwirl.Api/Users/UserApi.cs
+++ b/Backend/HulaSwirl.Api/Users/UserApi.cs
@@ -6,6 +6,7 @@ public static class UserApi
 
     public static IEndpointRouteBuilder MapUserApi(this IEndpointRouteBuilder app)
     {
+        app.Map("ws/users", UserEventsWebSocket.Handle);
         // 1) User erstellen
         app.MapPost(baseUrl, CreateUser.HandleCreate)
             .WithName(nameof(CreateUser.HandleCreate))

--- a/Backend/HulaSwirl.Api/Users/UserEventsWebSocket.cs
+++ b/Backend/HulaSwirl.Api/Users/UserEventsWebSocket.cs
@@ -1,0 +1,44 @@
+using System.Net.WebSockets;
+using HulaSwirl.Services.UserServices;
+
+namespace HulaSwirl.Api.Users;
+
+public static class UserEventsWebSocket
+{
+    public static async Task Handle(HttpContext httpContext, ObservableUserService service, JwtService jwtService)
+    {
+        if (!httpContext.WebSockets.IsWebSocketRequest)
+        {
+            httpContext.Response.StatusCode = 400;
+            return;
+        }
+
+        var token = httpContext.Request.Query["token"].FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            httpContext.Response.StatusCode = 400;
+            return;
+        }
+
+        try
+        {
+            var username = jwtService.GetUsernameFromToken($"Bearer {token}");
+            var socket = await httpContext.WebSockets.AcceptWebSocketAsync();
+            var observer = new UserWebSocketObserver(socket);
+            var subscription = service.Subscribe(username, observer);
+
+            var buffer = new byte[1024 * 4];
+            while (socket.State == WebSocketState.Open)
+            {
+                var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+                if (result.MessageType == WebSocketMessageType.Close)
+                    break;
+            }
+            subscription.Dispose();
+        }
+        catch
+        {
+            httpContext.Response.StatusCode = 401;
+        }
+    }
+}

--- a/Backend/HulaSwirl.Services/UserServices/JwtService.cs
+++ b/Backend/HulaSwirl.Services/UserServices/JwtService.cs
@@ -30,6 +30,7 @@ public class JwtService
             issuer: _config["Jwt:Issuer"],
             audience: _config["Jwt:Audience"],
             claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
             signingCredentials: creds);
 
         return new JwtSecurityTokenHandler().WriteToken(token);

--- a/Backend/HulaSwirl.Services/UserServices/ObservableUserService.cs
+++ b/Backend/HulaSwirl.Services/UserServices/ObservableUserService.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace HulaSwirl.Services.UserServices;
+
+public class UserEvent
+{
+    public string EventType { get; set; } = string.Empty; // "deleted" or "role-changed"
+    public string? Role { get; set; }
+}
+
+public class ObservableUserService
+{
+    private readonly Dictionary<string, List<IObserver<UserEvent>>> _observers = new();
+
+    public IDisposable Subscribe(string username, IObserver<UserEvent> observer)
+    {
+        if (!_observers.TryGetValue(username, out var list))
+        {
+            list = [];
+            _observers[username] = list;
+        }
+        if (!list.Contains(observer))
+            list.Add(observer);
+        return new Unsubscriber(list, observer);
+    }
+
+    public async Task BroadcastAsync(string username, UserEvent evt)
+    {
+        if (_observers.TryGetValue(username, out var list))
+        {
+            foreach (var observer in list.ToArray())
+            {
+                observer.OnNext(evt);
+            }
+        }
+        await Task.CompletedTask;
+    }
+
+    private class Unsubscriber : IDisposable
+    {
+        private readonly List<IObserver<UserEvent>> _list;
+        private readonly IObserver<UserEvent> _observer;
+
+        public Unsubscriber(List<IObserver<UserEvent>> list, IObserver<UserEvent> observer)
+        {
+            _list = list;
+            _observer = observer;
+        }
+
+        public void Dispose()
+        {
+            if (_list.Contains(_observer))
+                _list.Remove(_observer);
+        }
+    }
+}

--- a/Backend/HulaSwirl.Services/UserServices/UserWebSocketObserver.cs
+++ b/Backend/HulaSwirl.Services/UserServices/UserWebSocketObserver.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+
+namespace HulaSwirl.Services.UserServices;
+
+public class UserWebSocketObserver(WebSocket webSocket) : IObserver<UserEvent>
+{
+    public void OnCompleted() { }
+    public void OnError(Exception error) { }
+
+    public void OnNext(UserEvent value)
+    {
+        if (webSocket.State != WebSocketState.Open) return;
+        var json = JsonSerializer.Serialize(value, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        var buffer = Encoding.UTF8.GetBytes(json);
+        webSocket.SendAsync(buffer, WebSocketMessageType.Text, true, CancellationToken.None).GetAwaiter().GetResult();
+    }
+}

--- a/Frontend/src/app/app.config.ts
+++ b/Frontend/src/app/app.config.ts
@@ -7,6 +7,7 @@ import {loadingInterceptor} from './services/loading.interceptor';
 
 export const BASE_URL = new InjectionToken<string>('BaseUrl');
 export const WS_URL = new InjectionToken<string>('WsUrl');
+export const USER_WS_URL = new InjectionToken<string>('UserWsUrl');
 const IP = "192.168.0.200:8080";
 //const IP = "localhost:5110";
 
@@ -17,5 +18,6 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(withFetch(), withInterceptors([loadingInterceptor])),
     { provide: BASE_URL, useValue: `http://${IP}/api/v1` },
     { provide: WS_URL, useValue: `ws://${IP}/ws/orders` },
+    { provide: USER_WS_URL, useValue: `ws://${IP}/ws/users` },
   ]
 };

--- a/Frontend/src/app/services/user.service.ts
+++ b/Frontend/src/app/services/user.service.ts
@@ -2,7 +2,7 @@ import {effect, inject, Injectable, signal} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {firstValueFrom} from 'rxjs';
 import {ErrorService} from './error.service';
-import {BASE_URL} from '../app.config';
+import {BASE_URL, USER_WS_URL} from '../app.config';
 import {Router} from '@angular/router';
 
 interface RegisterRequest {
@@ -41,6 +41,8 @@ export class UserService {
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
   private apiBaseUrl = inject(BASE_URL);
+  private userWsUrl = inject(USER_WS_URL);
+  private ws?: WebSocket;
 
   jwt = signal<string | null>(this.getTokenFromStorage());
   username = signal<string | null>(this.getUsernameFromStorage());
@@ -52,6 +54,9 @@ export class UserService {
     effect(async () => {
       await this.updateUserRole();
     });
+    if (this.jwt()) {
+      this.connectWebSocket();
+    }
   }
 
   public getTokenFromStorage(): string | null {
@@ -82,11 +87,33 @@ export class UserService {
     this.username.set(null);
   }
 
+  private connectWebSocket() {
+    const token = this.getTokenFromStorage();
+    if (!token) {
+      return;
+    }
+    this.ws = new WebSocket(`${this.userWsUrl}?token=${token}`);
+    this.ws.onmessage = async evt => {
+      const data: { eventType: string; role?: string } = JSON.parse(evt.data);
+      if (data.eventType === 'deleted') {
+        await this.logout();
+      } else if (data.eventType === 'role-changed') {
+        await this.updateUserRole();
+      }
+    };
+    this.ws.onerror = () => console.error('WS-Error user');
+  }
+
+  private disconnectWebSocket() {
+    this.ws?.close();
+  }
+
   async register(username: string, key: string): Promise<void> {
     const url = `${this.apiBaseUrl}/users`;
     const payload: RegisterRequest = {username, key};
     const res = await firstValueFrom(this.http.post<AuthResponse>(url, payload));
     this.setToken(res.token, res.username);
+    this.connectWebSocket();
   }
 
   async login(username: string, key: string): Promise<void> {
@@ -95,10 +122,12 @@ export class UserService {
     const res = await firstValueFrom(this.http.post<AuthResponse>(url, payload));
     this.setToken(res.token, res.username);
     await this.updateUserRole();
+    this.connectWebSocket();
   }
 
   async logout() {
     this.clearToken();
+    this.disconnectWebSocket();
     await this.updateUserRole();
     await this.router.navigate(['/home']);
   }


### PR DESCRIPTION
## Summary
- add observable service for user events
- notify clients of account deletes and role changes via websocket
- refresh user role claims on each request
- expire JWTs after one hour
- expose `/ws/users` for realtime account updates
- auto connect frontend to `/ws/users`

## Testing
- `dotnet build Backend/Backend.sln` *(fails: command not found)*
- `npm test --silent` *(fails: Chrome binary missing)*
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_685da0aa37248322b46e03c2e3dd9dfb