### PR TITLE
Add statistics API and frontend display

### DIFF
--- a/Backend/HulaSwirl.Api/Program.cs
+++ b/Backend/HulaSwirl.Api/Program.cs
@@ -5,6 +5,7 @@ using HulaSwirl.Api.Drinks;
 using HulaSwirl.Api.Ingredients;
 using HulaSwirl.Api.Orders;
 using HulaSwirl.Api.Users;
+using HulaSwirl.Api.Statistics;
 using HulaSwirl.Services.DataAccess;
 using HulaSwirl.Services.OrderService;
 using HulaSwirl.Services.Pumps;
@@ -133,12 +134,13 @@ if (app.Environment.IsDevelopment()) app.MapOpenApi();
 
 app.UseHttpsRedirection();
 
-app.UseWebSockets();
-app
-    .MapIngredientApis()
-    .MapDrinkApis()
-    .MapUserApi()
-    .MapOrderApis();
+    app.UseWebSockets();
+    app
+        .MapIngredientApis()
+        .MapDrinkApis()
+        .MapUserApi()
+        .MapOrderApis()
+        .MapStatisticsApi();
 
 using (var scope = app.Services.CreateScope())
 {

--- a/Backend/HulaSwirl.Api/Statistics/GetDrinkStatistics.cs
+++ b/Backend/HulaSwirl.Api/Statistics/GetDrinkStatistics.cs
@@ -1,0 +1,28 @@
+using HulaSwirl.Services.DataAccess;
+using HulaSwirl.Services.Dtos;
+using HulaSwirl.Services.UserServices;
+using Microsoft.EntityFrameworkCore;
+
+namespace HulaSwirl.Api.Statistics;
+
+public static class GetDrinkStatistics
+{
+    public static async Task<IResult> Handle(AppDbContext db, HttpContext http)
+    {
+        if (!http.IsAdmin()) return Results.Forbid();
+
+        var stats = await db.Order
+            .Include(o => o.OrderIngredients)
+            .GroupBy(o => o.DrinkName)
+            .Select(g => new DrinkStatisticsDto
+            {
+                DrinkName = g.Key,
+                Count = g.Count(),
+                TotalAmount = g.SelectMany(o => o.OrderIngredients).Sum(i => i.Amount)
+            })
+            .OrderByDescending(d => d.Count)
+            .ToListAsync();
+
+        return Results.Ok(stats);
+    }
+}

--- a/Backend/HulaSwirl.Api/Statistics/GetDrinkStatistics.cs
+++ b/Backend/HulaSwirl.Api/Statistics/GetDrinkStatistics.cs
@@ -7,21 +7,26 @@ namespace HulaSwirl.Api.Statistics;
 
 public static class GetDrinkStatistics
 {
-    public static async Task<IResult> Handle(AppDbContext db, HttpContext http)
+    public static async Task<IResult> HandleGetDrinkStats(AppDbContext db, HttpContext http)
     {
         if (!http.IsAdmin()) return Results.Forbid();
 
-        var stats = await db.Order
+        // Step 1: Fetch required data from DB
+        var orders = await db.Order
             .Include(o => o.OrderIngredients)
+            .ToListAsync();
+
+        // Step 2: Group and aggregate in memory
+        var stats = orders
             .GroupBy(o => o.DrinkName)
             .Select(g => new DrinkStatisticsDto
             {
                 DrinkName = g.Key,
                 Count = g.Count(),
-                TotalAmount = g.SelectMany(o => o.OrderIngredients).Sum(i => i.Amount)
+                TotalAmount = g.SelectMany(o => o.OrderIngredients).Sum(o => o.Amount)
             })
             .OrderByDescending(d => d.Count)
-            .ToListAsync();
+            .ToList();
 
         return Results.Ok(stats);
     }

--- a/Backend/HulaSwirl.Api/Statistics/GetIngredientStatistics.cs
+++ b/Backend/HulaSwirl.Api/Statistics/GetIngredientStatistics.cs
@@ -7,11 +7,12 @@ namespace HulaSwirl.Api.Statistics;
 
 public static class GetIngredientStatistics
 {
-    public static async Task<IResult> Handle(AppDbContext db, HttpContext http)
+    public static async Task<IResult> HandleGetIngredientStats(AppDbContext db, HttpContext http)
     {
         if (!http.IsAdmin()) return Results.Forbid();
 
-        var stats = await db.Order
+        var orders = await db.Order.ToListAsync();
+        var stats = orders
             .SelectMany(o => o.OrderIngredients)
             .GroupBy(i => i.IngredientName)
             .Select(g => new IngredientStatisticsDto
@@ -21,7 +22,7 @@ public static class GetIngredientStatistics
                 TotalAmount = g.Sum(x => x.Amount)
             })
             .OrderByDescending(s => s.UsageCount)
-            .ToListAsync();
+            .ToList();
 
         return Results.Ok(stats);
     }

--- a/Backend/HulaSwirl.Api/Statistics/GetIngredientStatistics.cs
+++ b/Backend/HulaSwirl.Api/Statistics/GetIngredientStatistics.cs
@@ -1,0 +1,28 @@
+using HulaSwirl.Services.DataAccess;
+using HulaSwirl.Services.Dtos;
+using HulaSwirl.Services.UserServices;
+using Microsoft.EntityFrameworkCore;
+
+namespace HulaSwirl.Api.Statistics;
+
+public static class GetIngredientStatistics
+{
+    public static async Task<IResult> Handle(AppDbContext db, HttpContext http)
+    {
+        if (!http.IsAdmin()) return Results.Forbid();
+
+        var stats = await db.Order
+            .SelectMany(o => o.OrderIngredients)
+            .GroupBy(i => i.IngredientName)
+            .Select(g => new IngredientStatisticsDto
+            {
+                IngredientName = g.Key,
+                UsageCount = g.Count(),
+                TotalAmount = g.Sum(x => x.Amount)
+            })
+            .OrderByDescending(s => s.UsageCount)
+            .ToListAsync();
+
+        return Results.Ok(stats);
+    }
+}

--- a/Backend/HulaSwirl.Api/Statistics/GetRecentOrders.cs
+++ b/Backend/HulaSwirl.Api/Statistics/GetRecentOrders.cs
@@ -7,31 +7,33 @@ namespace HulaSwirl.Api.Statistics;
 
 public static class GetRecentOrders
 {
-    public static async Task<IResult> Handle(AppDbContext db, HttpContext http)
+    public static async Task<IResult> HandleGetRecentOrderStats(AppDbContext db, HttpContext http)
     {
         if (!http.IsAdmin()) return Results.Forbid();
-
-        var now = DateTime.UtcNow;
-        var start = now.AddHours(-24);
+        
+        // Time now without seconds, milliseconds, and microseconds
+        var now = DateTime.Now.AddMinutes(60 - DateTime.Now.Minute);
+        var start = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, 0, DateTimeKind.Local).AddHours(-12);
+        var end = start.AddHours(12);
 
         var grouped = await db.Order
-            .Where(o => o.OrderDate >= start && o.OrderDate <= now)
+            .Where(o => o.OrderDate >= start && o.OrderDate <= end)
             .GroupBy(o => new {
                 o.OrderDate.Year,
                 o.OrderDate.Month,
                 o.OrderDate.Day,
-                Hour = o.OrderDate.Hour,
+                o.OrderDate.Hour,
                 Minute = o.OrderDate.Minute < 30 ? 0 : 30
             })
             .Select(g => new IntervalStatisticDto
             {
-                IntervalStart = new DateTime(g.Key.Year, g.Key.Month, g.Key.Day, g.Key.Hour, g.Key.Minute, 0, DateTimeKind.Utc),
+                IntervalStart = new DateTime(g.Key.Year, g.Key.Month, g.Key.Day, g.Key.Hour, g.Key.Minute, 0, DateTimeKind.Local),
                 Count = g.Count()
             })
             .ToListAsync();
 
         var result = new List<IntervalStatisticDto>();
-        for (var i = 0; i < 48; i++)
+        for (var i = 0; i < 24; i++)
         {
             var intervalStart = start.AddMinutes(30 * i);
             var entry = grouped.FirstOrDefault(g => g.IntervalStart == intervalStart);

--- a/Backend/HulaSwirl.Api/Statistics/GetRecentOrders.cs
+++ b/Backend/HulaSwirl.Api/Statistics/GetRecentOrders.cs
@@ -1,0 +1,47 @@
+using HulaSwirl.Services.DataAccess;
+using HulaSwirl.Services.Dtos;
+using HulaSwirl.Services.UserServices;
+using Microsoft.EntityFrameworkCore;
+
+namespace HulaSwirl.Api.Statistics;
+
+public static class GetRecentOrders
+{
+    public static async Task<IResult> Handle(AppDbContext db, HttpContext http)
+    {
+        if (!http.IsAdmin()) return Results.Forbid();
+
+        var now = DateTime.UtcNow;
+        var start = now.AddHours(-24);
+
+        var grouped = await db.Order
+            .Where(o => o.OrderDate >= start && o.OrderDate <= now)
+            .GroupBy(o => new {
+                o.OrderDate.Year,
+                o.OrderDate.Month,
+                o.OrderDate.Day,
+                Hour = o.OrderDate.Hour,
+                Minute = o.OrderDate.Minute < 30 ? 0 : 30
+            })
+            .Select(g => new IntervalStatisticDto
+            {
+                IntervalStart = new DateTime(g.Key.Year, g.Key.Month, g.Key.Day, g.Key.Hour, g.Key.Minute, 0, DateTimeKind.Utc),
+                Count = g.Count()
+            })
+            .ToListAsync();
+
+        var result = new List<IntervalStatisticDto>();
+        for (var i = 0; i < 48; i++)
+        {
+            var intervalStart = start.AddMinutes(30 * i);
+            var entry = grouped.FirstOrDefault(g => g.IntervalStart == intervalStart);
+            result.Add(new IntervalStatisticDto
+            {
+                IntervalStart = intervalStart,
+                Count = entry?.Count ?? 0
+            });
+        }
+
+        return Results.Ok(result);
+    }
+}

--- a/Backend/HulaSwirl.Api/Statistics/GetUserStatistics.cs
+++ b/Backend/HulaSwirl.Api/Statistics/GetUserStatistics.cs
@@ -7,11 +7,12 @@ namespace HulaSwirl.Api.Statistics;
 
 public static class GetUserStatistics
 {
-    public static async Task<IResult> Handle(AppDbContext db, HttpContext http)
+    public static async Task<IResult> HandleGetUserStats(AppDbContext db, HttpContext http)
     {
         if (!http.IsAdmin()) return Results.Forbid();
 
-        var stats = await db.Order
+        var orders = await db.Order.ToListAsync();
+        var stats = orders
             .GroupBy(o => o.User)
             .Select(g => new UserStatisticsDto
             {
@@ -23,7 +24,7 @@ public static class GetUserStatistics
                     .ToList()
             })
             .OrderByDescending(u => u.TotalOrders)
-            .ToListAsync();
+            .ToList();
 
         return Results.Ok(stats);
     }

--- a/Backend/HulaSwirl.Api/Statistics/GetUserStatistics.cs
+++ b/Backend/HulaSwirl.Api/Statistics/GetUserStatistics.cs
@@ -1,0 +1,30 @@
+using HulaSwirl.Services.DataAccess;
+using HulaSwirl.Services.Dtos;
+using HulaSwirl.Services.UserServices;
+using Microsoft.EntityFrameworkCore;
+
+namespace HulaSwirl.Api.Statistics;
+
+public static class GetUserStatistics
+{
+    public static async Task<IResult> Handle(AppDbContext db, HttpContext http)
+    {
+        if (!http.IsAdmin()) return Results.Forbid();
+
+        var stats = await db.Order
+            .GroupBy(o => o.User)
+            .Select(g => new UserStatisticsDto
+            {
+                User = g.Key,
+                TotalOrders = g.Count(),
+                Drinks = g.GroupBy(o => o.DrinkName)
+                    .Select(d => new UserDrinkCountDto { DrinkName = d.Key, Count = d.Count() })
+                    .OrderByDescending(d => d.Count)
+                    .ToList()
+            })
+            .OrderByDescending(u => u.TotalOrders)
+            .ToListAsync();
+
+        return Results.Ok(stats);
+    }
+}

--- a/Backend/HulaSwirl.Api/Statistics/StatisticsApi.cs
+++ b/Backend/HulaSwirl.Api/Statistics/StatisticsApi.cs
@@ -1,0 +1,46 @@
+using HulaSwirl.Services.UserServices;
+using Microsoft.AspNetCore.Http;
+
+namespace HulaSwirl.Api.Statistics;
+
+public static class StatisticsApi
+{
+    public static IEndpointRouteBuilder MapStatisticsApi(this IEndpointRouteBuilder app)
+    {
+        const string baseUrl = "api/v1/statistics";
+
+        app.MapGet($"{baseUrl}/drinks", GetDrinkStatistics.Handle)
+            .WithName(nameof(GetDrinkStatistics.Handle))
+            .WithDescription("Get statistics per drink")
+            .WithTags("Statistics")
+            .RequireAuthorization()
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status403Forbidden);
+
+        app.MapGet($"{baseUrl}/ingredients", GetIngredientStatistics.Handle)
+            .WithName(nameof(GetIngredientStatistics.Handle))
+            .WithDescription("Get ingredient usage statistics")
+            .WithTags("Statistics")
+            .RequireAuthorization()
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status403Forbidden);
+
+        app.MapGet($"{baseUrl}/users", GetUserStatistics.Handle)
+            .WithName(nameof(GetUserStatistics.Handle))
+            .WithDescription("Get statistics per user")
+            .WithTags("Statistics")
+            .RequireAuthorization()
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status403Forbidden);
+
+        app.MapGet($"{baseUrl}/recent-orders", GetRecentOrders.Handle)
+            .WithName(nameof(GetRecentOrders.Handle))
+            .WithDescription("Get orders in 30 minute intervals for the last 24h")
+            .WithTags("Statistics")
+            .RequireAuthorization()
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status403Forbidden);
+
+        return app;
+    }
+}

--- a/Backend/HulaSwirl.Api/Statistics/StatisticsApi.cs
+++ b/Backend/HulaSwirl.Api/Statistics/StatisticsApi.cs
@@ -9,32 +9,32 @@ public static class StatisticsApi
     {
         const string baseUrl = "api/v1/statistics";
 
-        app.MapGet($"{baseUrl}/drinks", GetDrinkStatistics.Handle)
-            .WithName(nameof(GetDrinkStatistics.Handle))
+        app.MapGet($"{baseUrl}/drinks", GetDrinkStatistics.HandleGetDrinkStats)
+            .WithName(nameof(GetDrinkStatistics.HandleGetDrinkStats))
             .WithDescription("Get statistics per drink")
             .WithTags("Statistics")
             .RequireAuthorization()
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status403Forbidden);
 
-        app.MapGet($"{baseUrl}/ingredients", GetIngredientStatistics.Handle)
-            .WithName(nameof(GetIngredientStatistics.Handle))
+        app.MapGet($"{baseUrl}/ingredients", GetIngredientStatistics.HandleGetIngredientStats)
+            .WithName(nameof(GetIngredientStatistics.HandleGetIngredientStats))
             .WithDescription("Get ingredient usage statistics")
             .WithTags("Statistics")
             .RequireAuthorization()
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status403Forbidden);
 
-        app.MapGet($"{baseUrl}/users", GetUserStatistics.Handle)
-            .WithName(nameof(GetUserStatistics.Handle))
+        app.MapGet($"{baseUrl}/users", GetUserStatistics.HandleGetUserStats)
+            .WithName(nameof(GetUserStatistics.HandleGetUserStats))
             .WithDescription("Get statistics per user")
             .WithTags("Statistics")
             .RequireAuthorization()
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status403Forbidden);
 
-        app.MapGet($"{baseUrl}/recent-orders", GetRecentOrders.Handle)
-            .WithName(nameof(GetRecentOrders.Handle))
+        app.MapGet($"{baseUrl}/recent-orders", GetRecentOrders.HandleGetRecentOrderStats)
+            .WithName(nameof(GetRecentOrders.HandleGetRecentOrderStats))
             .WithDescription("Get orders in 30 minute intervals for the last 24h")
             .WithTags("Statistics")
             .RequireAuthorization()

--- a/Backend/HulaSwirl.Services/Dtos/StatisticsDtos.cs
+++ b/Backend/HulaSwirl.Services/Dtos/StatisticsDtos.cs
@@ -1,0 +1,34 @@
+namespace HulaSwirl.Services.Dtos;
+
+public class DrinkStatisticsDto
+{
+    public required string DrinkName { get; set; }
+    public required int Count { get; set; }
+    public required int TotalAmount { get; set; }
+}
+
+public class IngredientStatisticsDto
+{
+    public required string IngredientName { get; set; }
+    public required int UsageCount { get; set; }
+    public required int TotalAmount { get; set; }
+}
+
+public class UserDrinkCountDto
+{
+    public required string DrinkName { get; set; }
+    public required int Count { get; set; }
+}
+
+public class UserStatisticsDto
+{
+    public required string User { get; set; }
+    public required int TotalOrders { get; set; }
+    public required List<UserDrinkCountDto> Drinks { get; set; } = [];
+}
+
+public class IntervalStatisticDto
+{
+    public required DateTime IntervalStart { get; set; }
+    public required int Count { get; set; }
+}

--- a/Frontend/src/app/app.config.ts
+++ b/Frontend/src/app/app.config.ts
@@ -8,8 +8,8 @@ import {loadingInterceptor} from './services/loading.interceptor';
 export const BASE_URL = new InjectionToken<string>('BaseUrl');
 export const WS_URL = new InjectionToken<string>('WsUrl');
 export const USER_WS_URL = new InjectionToken<string>('UserWsUrl');
-const IP = "192.168.0.200:8080";
-//const IP = "localhost:5110";
+//const IP = "192.168.0.200:8080";
+const IP = "localhost:5110";
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/Frontend/src/app/services/statistics.service.ts
+++ b/Frontend/src/app/services/statistics.service.ts
@@ -1,0 +1,85 @@
+import {inject, Injectable, signal, WritableSignal} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {firstValueFrom} from 'rxjs';
+import {BASE_URL} from '../app.config';
+import {UserService} from './user.service';
+
+export interface DrinkStat {
+  drinkName: string;
+  count: number;
+  totalAmount: number;
+}
+
+export interface IngredientStat {
+  ingredientName: string;
+  usageCount: number;
+  totalAmount: number;
+}
+
+export interface UserDrinkCount {
+  drinkName: string;
+  count: number;
+}
+
+export interface UserStat {
+  user: string;
+  totalOrders: number;
+  drinks: UserDrinkCount[];
+}
+
+export interface IntervalStat {
+  intervalStart: string;
+  count: number;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class StatisticsService {
+  private readonly http = inject(HttpClient);
+  private readonly userService = inject(UserService);
+  private apiBaseUrl = inject(BASE_URL);
+
+  drinkStats: WritableSignal<DrinkStat[]> = signal([]);
+  ingredientStats: WritableSignal<IngredientStat[]> = signal([]);
+  userStats: WritableSignal<UserStat[]> = signal([]);
+  intervalStats: WritableSignal<IntervalStat[]> = signal([]);
+
+  private get headers() {
+    const jwt = this.userService.getTokenFromStorage();
+    return { Authorization: `Bearer ${jwt}` };
+  }
+
+  async loadAll() {
+    await Promise.all([
+      this.loadDrinkStats(),
+      this.loadIngredientStats(),
+      this.loadUserStats(),
+      this.loadIntervalStats()
+    ]);
+  }
+
+  async loadDrinkStats() {
+    this.drinkStats.set(
+      await firstValueFrom(this.http.get<DrinkStat[]>(`${this.apiBaseUrl}/statistics/drinks`, {headers: this.headers}))
+    );
+  }
+
+  async loadIngredientStats() {
+    this.ingredientStats.set(
+      await firstValueFrom(this.http.get<IngredientStat[]>(`${this.apiBaseUrl}/statistics/ingredients`, {headers: this.headers}))
+    );
+  }
+
+  async loadUserStats() {
+    this.userStats.set(
+      await firstValueFrom(this.http.get<UserStat[]>(`${this.apiBaseUrl}/statistics/users`, {headers: this.headers}))
+    );
+  }
+
+  async loadIntervalStats() {
+    this.intervalStats.set(
+      await firstValueFrom(this.http.get<IntervalStat[]>(`${this.apiBaseUrl}/statistics/recent-orders`, {headers: this.headers}))
+    );
+  }
+}

--- a/Frontend/src/app/statistics/statistics.component.css
+++ b/Frontend/src/app/statistics/statistics.component.css
@@ -19,6 +19,8 @@
   align-items: flex-end;
   gap: 4px;
   height: 200px;
+  overflow-x: scroll;
+  overflow-y: hidden;
 }
 
 .bar {
@@ -26,6 +28,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: flex-end;
+  height: 100%;
 }
 
 .bar-inner {
@@ -36,4 +40,5 @@
 
 .bar span {
   font-size: 0.7rem;
+  transform: rotate(-20deg);
 }

--- a/Frontend/src/app/statistics/statistics.component.css
+++ b/Frontend/src/app/statistics/statistics.component.css
@@ -1,0 +1,39 @@
+.stats-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.stat-card {
+  background: #f1e3cc;
+  padding: 1rem;
+  border-radius: 10px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  min-width: 200px;
+}
+
+.chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  height: 200px;
+}
+
+.bar {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.bar-inner {
+  width: 100%;
+  background: #6091af;
+  transition: height 0.3s ease;
+}
+
+.bar span {
+  font-size: 0.7rem;
+}

--- a/Frontend/src/app/statistics/statistics.component.html
+++ b/Frontend/src/app/statistics/statistics.component.html
@@ -1,1 +1,37 @@
-<p>statistics works!</p>
+<div class="container">
+  <h2>Orders per Drink</h2>
+  <div class="stats-grid">
+    <div class="stat-card" *ngFor="let d of drinks()">
+      <h3>{{ d.drinkName }}</h3>
+      <p>Total Orders: {{ d.count }}</p>
+      <p>Total Amount: {{ d.totalAmount }} ml</p>
+    </div>
+  </div>
+
+  <h2>Orders per User</h2>
+  <div class="stats-grid users">
+    <div class="stat-card" *ngFor="let u of users()">
+      <h3>{{ u.user }} ({{ u.totalOrders }})</h3>
+      <ul>
+        <li *ngFor="let d of u.drinks">{{ d.drinkName }} – {{ d.count }}</li>
+      </ul>
+    </div>
+  </div>
+
+  <h2>Ingredient Usage</h2>
+  <div class="stats-grid">
+    <div class="stat-card" *ngFor="let i of ingredients()">
+      <h3>{{ i.ingredientName }}</h3>
+      <p>Used: {{ i.usageCount }}x</p>
+      <p>Total Amount: {{ i.totalAmount }} ml</p>
+    </div>
+  </div>
+
+  <h2>Last 24h Orders</h2>
+  <div class="chart">
+    <div class="bar" *ngFor="let i of intervals()">
+      <div class="bar-inner" [style.height]="barHeight(i.count)"></div>
+      <span>{{ i.intervalStart | date:'HH:mm' }}</span>
+    </div>
+  </div>
+</div>

--- a/Frontend/src/app/statistics/statistics.component.html
+++ b/Frontend/src/app/statistics/statistics.component.html
@@ -27,7 +27,7 @@
     </div>
   </div>
 
-  <h2>Last 24h Orders</h2>
+  <h2>Last 12h Orders</h2>
   <div class="chart">
     <div class="bar" *ngFor="let i of intervals()">
       <div class="bar-inner" [style.height]="barHeight(i.count)"></div>

--- a/Frontend/src/app/statistics/statistics.component.ts
+++ b/Frontend/src/app/statistics/statistics.component.ts
@@ -1,11 +1,30 @@
-import { Component } from '@angular/core';
+import {Component, effect, inject, OnInit, signal} from '@angular/core';
+import {NgForOf, DatePipe} from '@angular/common';
+import {StatisticsService} from '../services/statistics.service';
 
 @Component({
   selector: 'app-statistics',
-  imports: [],
+  imports: [NgForOf, DatePipe],
   templateUrl: './statistics.component.html',
   styleUrl: './statistics.component.css'
 })
-export class StatisticsComponent {
+export class StatisticsComponent implements OnInit {
+  private readonly statisticsService = inject(StatisticsService);
 
+  drinks = this.statisticsService.drinkStats;
+  users = this.statisticsService.userStats;
+  ingredients = this.statisticsService.ingredientStats;
+  intervals = this.statisticsService.intervalStats;
+
+  ngOnInit(): void {
+    this.statisticsService.loadAll();
+  }
+
+  maxInterval() {
+    return Math.max(...this.intervals().map(i => i.count), 1);
+  }
+
+  barHeight(count: number): string {
+    return (count / this.maxInterval() * 100) + '%';
+  }
 }

--- a/Frontend/src/styles.css
+++ b/Frontend/src/styles.css
@@ -195,6 +195,7 @@ html{
 /* Scrollbar */
 ::-webkit-scrollbar {
   width: 5px;
+  height: 5px;
 }
 
 ::-webkit-scrollbar-track {


### PR DESCRIPTION
## Summary
- build statistics DTOs and API endpoints
- serve statistics in Program.cs
- implement Angular statistics service and component
- style statistics page

## Testing
- `dotnet build Backend.sln` *(fails: command not found)*
- `npm test` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68616d3641088322afe54637036b17cb