### PR TITLE
Enhance statistics with charts and time range support

### DIFF
--- a/Backend/HulaSwirl.Api/Statistics/GetDrinkStatistics.cs
+++ b/Backend/HulaSwirl.Api/Statistics/GetDrinkStatistics.cs
@@ -7,14 +7,21 @@ namespace HulaSwirl.Api.Statistics;
 
 public static class GetDrinkStatistics
 {
-    public static async Task<IResult> HandleGetDrinkStats(AppDbContext db, HttpContext http)
+    public static async Task<IResult> HandleGetDrinkStats(AppDbContext db, HttpContext http, DateTime? start, DateTime? end)
     {
         if (!http.IsAdmin()) return Results.Forbid();
 
-        // Step 1: Fetch required data from DB
-        var orders = await db.Order
+        var query = db.Order
             .Include(o => o.OrderIngredients)
-            .ToListAsync();
+            .AsQueryable();
+
+        if (start.HasValue)
+            query = query.Where(o => o.OrderDate >= start.Value);
+
+        if (end.HasValue)
+            query = query.Where(o => o.OrderDate <= end.Value);
+
+        var orders = await query.ToListAsync();
 
         // Step 2: Group and aggregate in memory
         var stats = orders

--- a/Backend/HulaSwirl.Api/Statistics/GetIngredientStatistics.cs
+++ b/Backend/HulaSwirl.Api/Statistics/GetIngredientStatistics.cs
@@ -7,11 +7,17 @@ namespace HulaSwirl.Api.Statistics;
 
 public static class GetIngredientStatistics
 {
-    public static async Task<IResult> HandleGetIngredientStats(AppDbContext db, HttpContext http)
+    public static async Task<IResult> HandleGetIngredientStats(AppDbContext db, HttpContext http, DateTime? start, DateTime? end)
     {
         if (!http.IsAdmin()) return Results.Forbid();
 
-        var orders = await db.Order.ToListAsync();
+        var query = db.Order.AsQueryable();
+        if (start.HasValue)
+            query = query.Where(o => o.OrderDate >= start.Value);
+        if (end.HasValue)
+            query = query.Where(o => o.OrderDate <= end.Value);
+
+        var orders = await query.ToListAsync();
         var stats = orders
             .SelectMany(o => o.OrderIngredients)
             .GroupBy(i => i.IngredientName)

--- a/Backend/HulaSwirl.Api/Statistics/GetRecentOrders.cs
+++ b/Backend/HulaSwirl.Api/Statistics/GetRecentOrders.cs
@@ -7,14 +7,17 @@ namespace HulaSwirl.Api.Statistics;
 
 public static class GetRecentOrders
 {
-    public static async Task<IResult> HandleGetRecentOrderStats(AppDbContext db, HttpContext http)
+    public static async Task<IResult> HandleGetRecentOrderStats(AppDbContext db, HttpContext http, DateTime? start, DateTime? end)
     {
         if (!http.IsAdmin()) return Results.Forbid();
-        
-        // Time now without seconds, milliseconds, and microseconds
-        var now = DateTime.Now.AddMinutes(60 - DateTime.Now.Minute);
-        var start = new DateTime(now.Year, now.Month, now.Day, now.Hour, now.Minute, 0, DateTimeKind.Local).AddHours(-12);
-        var end = start.AddHours(12);
+
+        var now = DateTime.Now;
+        if (!start.HasValue || !end.HasValue)
+        {
+            var defaultEnd = new DateTime(now.Year, now.Month, now.Day, now.Hour, 0, 0, DateTimeKind.Local);
+            end ??= defaultEnd;
+            start ??= end.Value.AddHours(-12);
+        }
 
         var grouped = await db.Order
             .Where(o => o.OrderDate >= start && o.OrderDate <= end)
@@ -23,7 +26,11 @@ public static class GetRecentOrders
                 o.OrderDate.Month,
                 o.OrderDate.Day,
                 o.OrderDate.Hour,
-                Minute = o.OrderDate.Minute < 30 ? 0 : 30
+                Minute = (end.Value - start.Value).TotalHours <= 6
+                    ? (o.OrderDate.Minute < 15 ? 0 : o.OrderDate.Minute < 30 ? 15 : o.OrderDate.Minute < 45 ? 30 : 45)
+                    : (end.Value - start.Value).TotalHours <= 12
+                        ? (o.OrderDate.Minute < 30 ? 0 : 30)
+                        : 0
             })
             .Select(g => new IntervalStatisticDto
             {
@@ -32,14 +39,19 @@ public static class GetRecentOrders
             })
             .ToListAsync();
 
+        var step = (end.Value - start.Value).TotalHours <= 6
+            ? TimeSpan.FromMinutes(15)
+            : (end.Value - start.Value).TotalHours <= 12
+                ? TimeSpan.FromMinutes(30)
+                : TimeSpan.FromHours(1);
+
         var result = new List<IntervalStatisticDto>();
-        for (var i = 0; i < 24; i++)
+        for (var t = start.Value; t < end.Value; t += step)
         {
-            var intervalStart = start.AddMinutes(30 * i);
-            var entry = grouped.FirstOrDefault(g => g.IntervalStart == intervalStart);
+            var entry = grouped.FirstOrDefault(g => g.IntervalStart == t);
             result.Add(new IntervalStatisticDto
             {
-                IntervalStart = intervalStart,
+                IntervalStart = t,
                 Count = entry?.Count ?? 0
             });
         }

--- a/Backend/HulaSwirl.Api/Statistics/GetUserStatistics.cs
+++ b/Backend/HulaSwirl.Api/Statistics/GetUserStatistics.cs
@@ -7,11 +7,17 @@ namespace HulaSwirl.Api.Statistics;
 
 public static class GetUserStatistics
 {
-    public static async Task<IResult> HandleGetUserStats(AppDbContext db, HttpContext http)
+    public static async Task<IResult> HandleGetUserStats(AppDbContext db, HttpContext http, DateTime? start, DateTime? end)
     {
         if (!http.IsAdmin()) return Results.Forbid();
 
-        var orders = await db.Order.ToListAsync();
+        var query = db.Order.AsQueryable();
+        if (start.HasValue)
+            query = query.Where(o => o.OrderDate >= start.Value);
+        if (end.HasValue)
+            query = query.Where(o => o.OrderDate <= end.Value);
+
+        var orders = await query.ToListAsync();
         var stats = orders
             .GroupBy(o => o.User)
             .Select(g => new UserStatisticsDto

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -17,6 +17,8 @@
         "@angular/platform-browser": "^19.0.0",
         "@angular/platform-browser-dynamic": "^19.0.0",
         "@angular/router": "^19.0.0",
+        "chart.js": "^4.4.1",
+        "ng2-charts": "^8.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -500,7 +502,6 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.2.2.tgz",
       "integrity": "sha512-YLiydMiTSf7s/LKaLgNeWawspulqdo/47zcjs1sEkHOcmyN1yR2Q0zQdgSbtsvuNikaR4NMNgTybNTDnULl64A==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3132,6 +3133,12 @@
       "peerDependencies": {
         "tslib": "2"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
@@ -5839,6 +5846,18 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "node_modules/chart.js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.1.tgz",
+      "integrity": "sha512-C74QN1bxwV1v2PEujhmKjOZ7iUM4w6BWs23Md/6aOZZSlwMzeCIDGuZay++rBgChYru7/+QFeoQW0fQoP534Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=7"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -6776,7 +6795,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -9049,6 +9068,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -9776,6 +9801,24 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/ng2-charts": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-8.0.0.tgz",
+      "integrity": "sha512-nofsNHI2Zt+EAwT+BJBVg0kgOhNo9ukO4CxULlaIi7VwZSr7I1km38kWSoU41Oq6os6qqIh5srnL+CcV+RFPFA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.15",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": ">=19.0.0",
+        "@angular/common": ">=19.0.0",
+        "@angular/core": ">=19.0.0",
+        "@angular/platform-browser": ">=19.0.0",
+        "chart.js": "^3.4.0 || ^4.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
@@ -10444,7 +10487,7 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
       "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "entities": "^4.5.0"
       },

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -18,6 +18,8 @@
     "@angular/platform-browser": "^19.0.0",
     "@angular/platform-browser-dynamic": "^19.0.0",
     "@angular/router": "^19.0.0",
+    "chart.js": "^4.4.1",
+    "ng2-charts": "^8.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/Frontend/src/app/app.config.ts
+++ b/Frontend/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import {ApplicationConfig, InjectionToken, provideZoneChangeDetection} from '@angular/core';
 import {provideRouter, withComponentInputBinding} from '@angular/router';
+import {provideCharts, withDefaultRegisterables} from 'ng2-charts';
 
 import { routes } from './app.routes';
 import {provideHttpClient, withFetch, withInterceptors} from '@angular/common/http';
@@ -19,5 +20,6 @@ export const appConfig: ApplicationConfig = {
     { provide: BASE_URL, useValue: `http://${IP}/api/v1` },
     { provide: WS_URL, useValue: `ws://${IP}/ws/orders` },
     { provide: USER_WS_URL, useValue: `ws://${IP}/ws/users` },
+    provideCharts(withDefaultRegisterables()),
   ]
 };

--- a/Frontend/src/app/services/statistics.service.ts
+++ b/Frontend/src/app/services/statistics.service.ts
@@ -50,36 +50,55 @@ export class StatisticsService {
     return { Authorization: `Bearer ${jwt}` };
   }
 
-  async loadAll() {
+  async loadAll(start?: string, end?: string) {
     await Promise.all([
-      this.loadDrinkStats(),
-      this.loadIngredientStats(),
-      this.loadUserStats(),
-      this.loadIntervalStats()
+      this.loadDrinkStats(start, end),
+      this.loadIngredientStats(start, end),
+      this.loadUserStats(start, end),
+      this.loadIntervalStats(start, end)
     ]);
   }
 
-  async loadDrinkStats() {
+  private rangeParams(start?: string, end?: string) {
+    const params: any = {};
+    if (start) params.start = start;
+    if (end) params.end = end;
+    return params;
+  }
+
+  async loadDrinkStats(start?: string, end?: string) {
     this.drinkStats.set(
-      await firstValueFrom(this.http.get<DrinkStat[]>(`${this.apiBaseUrl}/statistics/drinks`, {headers: this.headers}))
+      await firstValueFrom(this.http.get<DrinkStat[]>(`${this.apiBaseUrl}/statistics/drinks`, {
+        headers: this.headers,
+        params: this.rangeParams(start, end)
+      }))
     );
   }
 
-  async loadIngredientStats() {
+  async loadIngredientStats(start?: string, end?: string) {
     this.ingredientStats.set(
-      await firstValueFrom(this.http.get<IngredientStat[]>(`${this.apiBaseUrl}/statistics/ingredients`, {headers: this.headers}))
+      await firstValueFrom(this.http.get<IngredientStat[]>(`${this.apiBaseUrl}/statistics/ingredients`, {
+        headers: this.headers,
+        params: this.rangeParams(start, end)
+      }))
     );
   }
 
-  async loadUserStats() {
+  async loadUserStats(start?: string, end?: string) {
     this.userStats.set(
-      await firstValueFrom(this.http.get<UserStat[]>(`${this.apiBaseUrl}/statistics/users`, {headers: this.headers}))
+      await firstValueFrom(this.http.get<UserStat[]>(`${this.apiBaseUrl}/statistics/users`, {
+        headers: this.headers,
+        params: this.rangeParams(start, end)
+      }))
     );
   }
 
-  async loadIntervalStats() {
+  async loadIntervalStats(start?: string, end?: string) {
     this.intervalStats.set(
-      await firstValueFrom(this.http.get<IntervalStat[]>(`${this.apiBaseUrl}/statistics/recent-orders`, {headers: this.headers}))
+      await firstValueFrom(this.http.get<IntervalStat[]>(`${this.apiBaseUrl}/statistics/recent-orders`, {
+        headers: this.headers,
+        params: this.rangeParams(start, end)
+      }))
     );
   }
 }

--- a/Frontend/src/app/statistics/statistics.component.css
+++ b/Frontend/src/app/statistics/statistics.component.css
@@ -14,31 +14,30 @@
   min-width: 200px;
 }
 
-.chart {
+.users .stat-card {
+  flex: 1 1 250px;
+}
+
+.date-picker {
   display: flex;
-  align-items: flex-end;
-  gap: 4px;
-  height: 200px;
-  overflow-x: scroll;
-  overflow-y: hidden;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 1rem;
 }
 
-.bar {
-  flex: 1;
+.pie-row {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-end;
-  height: 100%;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
 }
 
-.bar-inner {
-  width: 100%;
-  background: #6091af;
-  transition: height 0.3s ease;
+.pie-chart {
+  flex: 1 1 300px;
+  max-width: 400px;
 }
 
-.bar span {
-  font-size: 0.7rem;
-  transform: rotate(-20deg);
+canvas {
+  max-width: 100%;
 }
+

--- a/Frontend/src/app/statistics/statistics.component.html
+++ b/Frontend/src/app/statistics/statistics.component.html
@@ -1,10 +1,21 @@
 <div class="container">
-  <h2>Orders per Drink</h2>
-  <div class="stats-grid">
-    <div class="stat-card" *ngFor="let d of drinks()">
-      <h3>{{ d.drinkName }}</h3>
-      <p>Total Orders: {{ d.count }}</p>
-      <p>Total Amount: {{ d.totalAmount }} ml</p>
+  <div class="date-picker">
+    <label>Start
+      <input type="datetime-local" [(ngModel)]="start" (change)="reload()">
+    </label>
+    <label>End
+      <input type="datetime-local" [(ngModel)]="end" (change)="reload()">
+    </label>
+  </div>
+
+  <div class="pie-row">
+    <div class="pie-chart">
+      <h2>Orders per Drink</h2>
+      <canvas baseChart [data]="drinkChartData()" [options]="drinkChartOptions" [type]="'pie'"></canvas>
+    </div>
+    <div class="pie-chart">
+      <h2>Ingredient Usage</h2>
+      <canvas baseChart [data]="ingredientChartData()" [options]="ingredientChartOptions" [type]="'pie'"></canvas>
     </div>
   </div>
 
@@ -18,20 +29,6 @@
     </div>
   </div>
 
-  <h2>Ingredient Usage</h2>
-  <div class="stats-grid">
-    <div class="stat-card" *ngFor="let i of ingredients()">
-      <h3>{{ i.ingredientName }}</h3>
-      <p>Used: {{ i.usageCount }}x</p>
-      <p>Total Amount: {{ i.totalAmount }} ml</p>
-    </div>
-  </div>
-
-  <h2>Last 12h Orders</h2>
-  <div class="chart">
-    <div class="bar" *ngFor="let i of intervals()">
-      <div class="bar-inner" [style.height]="barHeight(i.count)"></div>
-      <span>{{ i.intervalStart | date:'HH:mm' }}</span>
-    </div>
-  </div>
+  <h2>Order Intervals</h2>
+  <canvas baseChart [data]="intervalChartData()" [options]="intervalChartOptions" [type]="'bar'"></canvas>
 </div>

--- a/Frontend/src/app/statistics/statistics.component.ts
+++ b/Frontend/src/app/statistics/statistics.component.ts
@@ -1,10 +1,13 @@
-import {Component, effect, inject, OnInit, signal} from '@angular/core';
+import {Component, effect, inject, OnInit, signal, WritableSignal} from '@angular/core';
 import {NgForOf, DatePipe} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+import {BaseChartDirective} from 'ng2-charts';
+import {ChartConfiguration, ChartData, ChartOptions, ChartType} from 'chart.js';
 import {StatisticsService} from '../services/statistics.service';
 
 @Component({
   selector: 'app-statistics',
-  imports: [NgForOf, DatePipe],
+  imports: [NgForOf, DatePipe, FormsModule, BaseChartDirective],
   templateUrl: './statistics.component.html',
   styleUrl: './statistics.component.css'
 })
@@ -16,8 +19,54 @@ export class StatisticsComponent implements OnInit {
   ingredients = this.statisticsService.ingredientStats;
   intervals = this.statisticsService.intervalStats;
 
+  start: string = '';
+  end: string = '';
+
+  drinkChartData: WritableSignal<ChartData<'pie'>> = signal({datasets: [], labels: []});
+  ingredientChartData: WritableSignal<ChartData<'pie'>> = signal({datasets: [], labels: []});
+  intervalChartData: WritableSignal<ChartData<'bar'>> = signal({datasets: [{data: []}], labels: []});
+  intervalChartOptions: ChartOptions<'bar'> = {responsive: true};
+
+  drinkAmounts: number[] = [];
+  ingredientAmounts: number[] = [];
+
+  drinkChartOptions: ChartOptions<'pie'> = {
+    responsive: true,
+    plugins: {
+      tooltip: {
+        callbacks: {
+          label: (ctx) => {
+            const count = ctx.parsed as number;
+            const amount = this.drinkAmounts[ctx.dataIndex];
+            return `${ctx.label}: ${count}x (${amount} ml)`;
+          }
+        }
+      }
+    }
+  };
+
+  ingredientChartOptions: ChartOptions<'pie'> = {
+    responsive: true,
+    plugins: {
+      tooltip: {
+        callbacks: {
+          label: (ctx) => {
+            const count = ctx.parsed as number;
+            const amount = this.ingredientAmounts[ctx.dataIndex];
+            return `${ctx.label}: ${count}x (${amount} ml)`;
+          }
+        }
+      }
+    }
+  };
+
   ngOnInit(): void {
     this.statisticsService.loadAll();
+    effect(() => {
+      this.buildDrinkChart();
+      this.buildIngredientChart();
+      this.buildIntervalChart();
+    });
   }
 
   maxInterval() {
@@ -26,5 +75,53 @@ export class StatisticsComponent implements OnInit {
 
   barHeight(count: number): string {
     return (count / this.maxInterval() * 100) + '%';
+  }
+
+  async reload() {
+    await this.statisticsService.loadAll(this.start, this.end);
+  }
+
+  private buildDrinkChart() {
+    const data = [...this.drinks()].sort((a,b) => b.count - a.count);
+    const top = data.slice(0,5);
+    const others = data.slice(5);
+    const otherCount = others.reduce((sum,d) => sum + d.count, 0);
+    const otherAmount = others.reduce((sum,d) => sum + d.totalAmount, 0);
+
+    const labels = top.map(d => d.drinkName);
+    const counts = top.map(d => d.count);
+    this.drinkAmounts = top.map(d => d.totalAmount);
+    if (others.length) {
+      labels.push('Others');
+      counts.push(otherCount);
+      this.drinkAmounts.push(otherAmount);
+    }
+
+    this.drinkChartData.set({labels, datasets: [{data: counts}]});
+  }
+
+  private buildIngredientChart() {
+    const data = [...this.ingredients()].sort((a,b) => b.usageCount - a.usageCount);
+    const top = data.slice(0,5);
+    const others = data.slice(5);
+    const otherCount = others.reduce((s,i)=>s+i.usageCount,0);
+    const otherAmount = others.reduce((s,i)=>s+i.totalAmount,0);
+
+    const labels = top.map(i=>i.ingredientName);
+    const counts = top.map(i=>i.usageCount);
+    this.ingredientAmounts = top.map(i=>i.totalAmount);
+    if(others.length){
+      labels.push('Others');
+      counts.push(otherCount);
+      this.ingredientAmounts.push(otherAmount);
+    }
+
+    this.ingredientChartData.set({labels, datasets:[{data: counts}]});
+  }
+
+  private buildIntervalChart() {
+    const labels = this.intervals().map(i=>new Date(i.intervalStart).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}));
+    const data = this.intervals().map(i=>i.count);
+    this.intervalChartData.set({labels, datasets:[{data}]});
   }
 }


### PR DESCRIPTION
## Summary
- add optional time range parameters to all statistics endpoints
- provide Chart.js in Angular configuration
- enable pie and bar charts with dynamic data
- improve user stat card layout
- allow selecting a custom time range

## Testing
- `npm run build`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a5a555d88322a8b5b2efe6b62617