### PR TITLE
Improve drink image loading

### DIFF
--- a/Frontend/src/app/app.component.ts
+++ b/Frontend/src/app/app.component.ts
@@ -75,7 +75,7 @@ export class AppComponent {
 
   async ngOnInit() {
     await this.ingredientService.loadIngredients();
-    await this.drinkService.loadDrinks();
+    this.drinkService.loadDrinks();
     this.router.events.subscribe(event => {
       if (event instanceof NavigationStart) {
         this.modalService.closeAll();

--- a/Frontend/src/app/drinks/drinks.component.css
+++ b/Frontend/src/app/drinks/drinks.component.css
@@ -23,3 +23,34 @@
 .drink-name {
   font-weight: bold;
 }
+
+.drink-card-image-container {
+  position: relative;
+}
+
+.image-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.05);
+}
+
+.image-placeholder::after {
+  content: '';
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 3px solid #ccc;
+  border-top-color: #333;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.hidden {
+  display: none;
+}

--- a/Frontend/src/app/drinks/drinks.component.html
+++ b/Frontend/src/app/drinks/drinks.component.html
@@ -25,7 +25,8 @@
         <div *ngIf="drink.available" class="drink-card" (click)="openModal(ModalType.EditDrink,drink)">
           <div class="drink-card-image-container">
             @if (drink.imgUrl) {
-              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
+              <div class="image-placeholder" *ngIf="imageLoading()[drink.id]"></div>
+              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name" (load)="onImageLoad(drink.id)" [class.hidden]="imageLoading()[drink.id]">
             } @else {
               <p>No image available</p>
             }
@@ -56,7 +57,8 @@
         <div *ngIf="!drink.available" class="drink-card manage" (click)="openModal(ModalType.EditDrink,drink)">
           <div class="drink-card-image-container">
             @if (drink.imgUrl) {
-              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
+              <div class="image-placeholder" *ngIf="imageLoading()[drink.id]"></div>
+              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name" (load)="onImageLoad(drink.id)" [class.hidden]="imageLoading()[drink.id]">
             } @else {
               <p>No image available</p>
             }

--- a/Frontend/src/app/drinks/drinks.component.ts
+++ b/Frontend/src/app/drinks/drinks.component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, effect, inject, signal} from '@angular/core';
+import {Component, computed, effect, inject, signal, WritableSignal} from '@angular/core';
 import {Drink, DrinkService} from '../services/drink.service';
 import {FormsModule} from '@angular/forms';
 import {NgForOf, NgIf} from '@angular/common';
@@ -28,6 +28,7 @@ export class DrinksComponent {
   selectedIngredient: string = '';
   allDrinks = signal<Drink[]>([]);
   allAvailableIngredients = signal<Ingredient[]>([]);
+  imageLoading: WritableSignal<Record<number, boolean>> = signal({});
 
   getUniqueIngredients(): string[] {
     const ingredientsSet = new Set<string>();
@@ -61,8 +62,16 @@ export class DrinksComponent {
       const allDrinks = this.drinkService.drinks();
       this.allAvailableIngredients.set(this.ingredientService.ingredients().filter(ing => ing.pumpSlot !== null));
       this.allDrinks.set(allDrinks);
+      const loadingMap: Record<number, boolean> = {};
+      allDrinks.forEach(d => loadingMap[d.id] = true);
+      this.imageLoading.set(loadingMap);
       this.filterDrinks();
     });
+  }
+  onImageLoad(id: number) {
+    const map = {...this.imageLoading()};
+    map[id] = false;
+    this.imageLoading.set(map);
   }
   openModal(m:ModalType,data:any=null) {
     this.modalService.openModal(m,data)

--- a/Frontend/src/app/services/drink.service.ts
+++ b/Frontend/src/app/services/drink.service.ts
@@ -1,6 +1,6 @@
 import {inject, Injectable, signal, WritableSignal} from '@angular/core';
 import {firstValueFrom, Observable} from 'rxjs';
-import {HttpClient, HttpErrorResponse, HttpResponse} from '@angular/common/http';
+import {HttpClient, HttpErrorResponse, HttpHeaders, HttpResponse} from '@angular/common/http';
 import {ErrorService} from './error.service';
 import {UserService} from './user.service';
 import {BASE_URL} from '../app.config';
@@ -31,7 +31,11 @@ export class DrinkService {
 
   async loadDrinks() {
     try {
-      this.drinks.set(await firstValueFrom(this.httpClient.get<Drink[]>(this.apiBaseUrl + "/drinks")));
+      const headers = new HttpHeaders({'X-Skip-Loader': 'true'});
+      const drinks = await firstValueFrom(
+        this.httpClient.get<Drink[]>(this.apiBaseUrl + "/drinks", {headers})
+      );
+      this.drinks.set(drinks);
     } catch (e) {
       console.error(`An error occurred while loading drinks.`, e);
     }

--- a/Frontend/src/app/services/loading.interceptor.ts
+++ b/Frontend/src/app/services/loading.interceptor.ts
@@ -1,10 +1,16 @@
-import { HttpInterceptorFn, HttpRequest, HttpHandlerFn } from '@angular/common/http';
-import { inject } from '@angular/core';
-import { finalize } from 'rxjs';
-import { LoadingService } from './loading.service';
+import {HttpInterceptorFn, HttpRequest, HttpHandlerFn, HttpHeaders} from '@angular/common/http';
+import {inject} from '@angular/core';
+import {finalize} from 'rxjs';
+import {LoadingService} from './loading.service';
 
 export const loadingInterceptor: HttpInterceptorFn = (req: HttpRequest<unknown>, next: HttpHandlerFn) => {
   const service = inject(LoadingService);
+  const skipLoading = req.headers.get('X-Skip-Loader');
+  if (skipLoading) {
+    const headers = req.headers.delete('X-Skip-Loader');
+    const newReq = req.clone({headers});
+    return next(newReq);
+  }
   service.start();
   return next(req).pipe(finalize(() => service.stop()));
 };


### PR DESCRIPTION
## Summary
- allow skipping the global loading spinner with `X-Skip-Loader` header
- load drinks without blocking the UI
- show placeholders for drink images while they load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866da2055e8832294ca181c4e6c561f