### PR TITLE
Improve UX with lazy loaded drink images

### DIFF
--- a/Frontend/src/app/drinks/drinks.component.html
+++ b/Frontend/src/app/drinks/drinks.component.html
@@ -25,7 +25,7 @@
         <div *ngIf="drink.available" class="drink-card" (click)="openModal(ModalType.EditDrink,drink)">
           <div class="drink-card-image-container">
             @if (drink.imgUrl) {
-              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
+              <app-lazy-image [src]="drink.imgUrl" [alt]="drink.name" class="drink-image"></app-lazy-image>
             } @else {
               <p>No image available</p>
             }
@@ -56,7 +56,7 @@
         <div *ngIf="!drink.available" class="drink-card manage" (click)="openModal(ModalType.EditDrink,drink)">
           <div class="drink-card-image-container">
             @if (drink.imgUrl) {
-              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
+              <app-lazy-image [src]="drink.imgUrl" [alt]="drink.name" class="drink-image"></app-lazy-image>
             } @else {
               <p>No image available</p>
             }

--- a/Frontend/src/app/drinks/drinks.component.ts
+++ b/Frontend/src/app/drinks/drinks.component.ts
@@ -2,6 +2,7 @@ import {Component, computed, effect, inject, signal} from '@angular/core';
 import {Drink, DrinkService} from '../services/drink.service';
 import {FormsModule} from '@angular/forms';
 import {NgForOf, NgIf} from '@angular/common';
+import {LazyImageComponent} from '../lazy-image/lazy-image.component';
 import {Ingredient, IngredientsService} from '../services/ingredients.service';
 import {ModalService, ModalType} from '../services/modal.service';
 import {ErrorService} from '../services/error.service';
@@ -11,7 +12,9 @@ import {ErrorService} from '../services/error.service';
   imports: [
     FormsModule,
     NgForOf,
-    NgIf],
+    NgIf,
+    LazyImageComponent
+  ],
   templateUrl: './drinks.component.html',
   standalone: true,
   styleUrl: './drinks.component.css'

--- a/Frontend/src/app/home/home.component.html
+++ b/Frontend/src/app/home/home.component.html
@@ -47,7 +47,7 @@
                [class.hidden]="getSlideState($index) === 'hidden'">
             <div class="drink-card-image-container">
             @if(drink.imgUrl) {
-              <img src="{{drink.imgUrl}}" alt="{{drink.name}}">
+              <app-lazy-image [src]="drink.imgUrl" [alt]="drink.name"></app-lazy-image>
             } @else {
               <p>No image available</p>
             }
@@ -80,7 +80,7 @@
       <div class="drink-card" (click)="openModal(ModalType.Order, drink)">
         <div class="drink-card-image-container">
           @if(drink.imgUrl) {
-            <img src="{{drink.imgUrl}}" alt="{{drink.name}}">
+            <app-lazy-image [src]="drink.imgUrl" [alt]="drink.name"></app-lazy-image>
           } @else {
             <p>No image available</p>
           }

--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -5,6 +5,7 @@ import {Drink, DrinkService} from '../services/drink.service';
 import {ModalService, ModalType} from '../services/modal.service';
 import {ErrorService} from '../services/error.service';
 import {NgForOf} from '@angular/common';
+import {LazyImageComponent} from '../lazy-image/lazy-image.component';
 import {FpsService} from '../services/fps.service';
 import {StatisticsService} from '../services/statistics.service';
 
@@ -12,7 +13,8 @@ import {StatisticsService} from '../services/statistics.service';
   selector: 'app-home',
   imports: [
     FormsModule,
-    NgForOf
+    NgForOf,
+    LazyImageComponent
   ],
   templateUrl: './home.component.html',
   standalone: true,

--- a/Frontend/src/app/lazy-image/lazy-image.component.css
+++ b/Frontend/src/app/lazy-image/lazy-image.component.css
@@ -1,0 +1,43 @@
+.image-wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.image-wrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.image-wrapper img.loaded {
+  opacity: 1;
+}
+
+.placeholder {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.placeholder .spinner {
+  width: 30px;
+  height: 30px;
+  border: 4px solid #ddd;
+  border-top: 4px solid #333;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/Frontend/src/app/lazy-image/lazy-image.component.html
+++ b/Frontend/src/app/lazy-image/lazy-image.component.html
@@ -1,0 +1,6 @@
+<div class="image-wrapper">
+  <img [src]="src" [attr.loading]="'lazy'" [alt]="alt" (load)="onLoad()" [class.loaded]="loaded" />
+  <div class="placeholder" *ngIf="!loaded">
+    <div class="spinner"></div>
+  </div>
+</div>

--- a/Frontend/src/app/lazy-image/lazy-image.component.ts
+++ b/Frontend/src/app/lazy-image/lazy-image.component.ts
@@ -1,0 +1,19 @@
+import {Component, Input} from '@angular/core';
+import {NgIf} from '@angular/common';
+
+@Component({
+  selector: 'app-lazy-image',
+  standalone: true,
+  imports: [NgIf],
+  templateUrl: './lazy-image.component.html',
+  styleUrl: './lazy-image.component.css'
+})
+export class LazyImageComponent {
+  @Input() src: string = '';
+  @Input() alt: string = '';
+  loaded = false;
+
+  onLoad() {
+    this.loaded = true;
+  }
+}

--- a/Frontend/src/app/modals/drink-modal/drink-modal.component.html
+++ b/Frontend/src/app/modals/drink-modal/drink-modal.component.html
@@ -3,7 +3,7 @@
     <div id="left-column">
       <div class="upload-box" [class.drag-over]="isDragging" (click)="fileInput.click()" (dragover)="onDragOver($event)" (dragleave)="onDragLeave($event)" (drop)="onDrop($event)">
         <span *ngIf="!imageBase64">Upload image</span>
-        <img *ngIf="imageBase64" [src]="imageBase64" alt="Drink image" class="preview-image"/>
+        <app-lazy-image *ngIf="imageBase64" [src]="imageBase64" alt="Drink image" class="preview-image"></app-lazy-image>
       </div>
       <input #fileInput type="file" accept="image/*" style="display: none" (change)="onFileSelected($event)"/>
       <div>

--- a/Frontend/src/app/modals/drink-modal/drink-modal.component.ts
+++ b/Frontend/src/app/modals/drink-modal/drink-modal.component.ts
@@ -7,13 +7,14 @@ import {
 } from '../../services/ingredients.service';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
+import {LazyImageComponent} from '../../lazy-image/lazy-image.component';
 import {GenericModalComponent} from '../generic-modal/generic-modal.component';
 import { Drink, DrinkBase, DrinkService } from '../../services/drink.service';
 import { ErrorHandlingComponent } from '../../services/error-handling';
 
 @Component({
   selector: 'app-drink-modal',
-  imports: [FormsModule, CommonModule, GenericModalComponent],
+  imports: [FormsModule, CommonModule, GenericModalComponent, LazyImageComponent],
   templateUrl: './drink-modal.component.html',
   standalone: true,
   styleUrls: ['./drink-modal.component.css'],

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
@@ -3,7 +3,7 @@
     <div id="drink-overview">
       @if (selectedDrink()?.imgUrl) {
       <div class="modal-image">
-        <img [src]="selectedDrink()!.imgUrl" alt="Drink Image" class="drink-image" />
+        <app-lazy-image [src]="selectedDrink()!.imgUrl" alt="Drink Image" class="drink-image"></app-lazy-image>
       </div>
       }
       <div id="modal-ingredient-list">

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.ts
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.ts
@@ -1,5 +1,6 @@
 import {Component, inject, signal, Signal, WritableSignal} from '@angular/core';
 import {NgForOf} from "@angular/common";
+import {LazyImageComponent} from '../../lazy-image/lazy-image.component';
 import {GenericModalComponent} from '../generic-modal/generic-modal.component';
 import {Drink, DrinkService} from '../../services/drink.service';
 import {ModalService, ModalType} from '../../services/modal.service';
@@ -11,7 +12,8 @@ import {FormsModule} from '@angular/forms';
   imports: [
     NgForOf,
     GenericModalComponent,
-    FormsModule
+    FormsModule,
+    LazyImageComponent
   ],
   templateUrl: './order-drink-modal.component.html',
   standalone: true,


### PR DESCRIPTION
## Summary
- add a `LazyImageComponent` that shows a spinner until images finish loading
- use the new component on pages and modals that display drinks
- import the component where needed so images no longer block interactions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866da2055e8832294ca181c4e6c561f