### PR TITLE
Improve drink image loading UX

### DIFF
--- a/Frontend/src/app/async-image/async-image.component.css
+++ b/Frontend/src/app/async-image/async-image.component.css
@@ -1,0 +1,30 @@
+.image-wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+.image-wrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+.image-wrapper img.loaded {
+  opacity: 1;
+}
+.spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 30px;
+  height: 30px;
+  margin: -15px 0 0 -15px;
+  border: 3px solid rgba(0,0,0,0.2);
+  border-top-color: rgba(0,0,0,0.6);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/Frontend/src/app/async-image/async-image.component.html
+++ b/Frontend/src/app/async-image/async-image.component.html
@@ -1,0 +1,4 @@
+<div class="image-wrapper">
+  <img [src]="src" [alt]="alt" (load)="loaded=true" [class.loaded]="loaded" />
+  <div class="spinner" *ngIf="!loaded"></div>
+</div>

--- a/Frontend/src/app/async-image/async-image.component.ts
+++ b/Frontend/src/app/async-image/async-image.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+import { NgIf } from '@angular/common';
+
+@Component({
+  selector: 'app-async-image',
+  standalone: true,
+  imports: [NgIf],
+  templateUrl: './async-image.component.html',
+  styleUrl: './async-image.component.css'
+})
+export class AsyncImageComponent {
+  @Input() src: string | null = null;
+  @Input() alt = '';
+  loaded = false;
+}

--- a/Frontend/src/app/drinks/drinks.component.html
+++ b/Frontend/src/app/drinks/drinks.component.html
@@ -25,7 +25,7 @@
         <div *ngIf="drink.available" class="drink-card" (click)="openModal(ModalType.EditDrink,drink)">
           <div class="drink-card-image-container">
             @if (drink.imgUrl) {
-              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
+              <app-async-image [src]="drink.imgUrl" [alt]="drink.name"></app-async-image>
             } @else {
               <p>No image available</p>
             }
@@ -56,7 +56,7 @@
         <div *ngIf="!drink.available" class="drink-card manage" (click)="openModal(ModalType.EditDrink,drink)">
           <div class="drink-card-image-container">
             @if (drink.imgUrl) {
-              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
+              <app-async-image [src]="drink.imgUrl" [alt]="drink.name"></app-async-image>
             } @else {
               <p>No image available</p>
             }

--- a/Frontend/src/app/drinks/drinks.component.ts
+++ b/Frontend/src/app/drinks/drinks.component.ts
@@ -2,6 +2,7 @@ import {Component, computed, effect, inject, signal} from '@angular/core';
 import {Drink, DrinkService} from '../services/drink.service';
 import {FormsModule} from '@angular/forms';
 import {NgForOf, NgIf} from '@angular/common';
+import {AsyncImageComponent} from '../async-image/async-image.component';
 import {Ingredient, IngredientsService} from '../services/ingredients.service';
 import {ModalService, ModalType} from '../services/modal.service';
 import {ErrorService} from '../services/error.service';
@@ -11,7 +12,8 @@ import {ErrorService} from '../services/error.service';
   imports: [
     FormsModule,
     NgForOf,
-    NgIf],
+    NgIf,
+    AsyncImageComponent],
   templateUrl: './drinks.component.html',
   standalone: true,
   styleUrl: './drinks.component.css'

--- a/Frontend/src/app/home/home.component.html
+++ b/Frontend/src/app/home/home.component.html
@@ -47,7 +47,7 @@
                [class.hidden]="getSlideState($index) === 'hidden'">
             <div class="drink-card-image-container">
             @if(drink.imgUrl) {
-              <img src="{{drink.imgUrl}}" alt="{{drink.name}}">
+              <app-async-image [src]="drink.imgUrl" [alt]="drink.name"></app-async-image>
             } @else {
               <p>No image available</p>
             }
@@ -80,7 +80,7 @@
       <div class="drink-card" (click)="openModal(ModalType.Order, drink)">
         <div class="drink-card-image-container">
           @if(drink.imgUrl) {
-            <img src="{{drink.imgUrl}}" alt="{{drink.name}}">
+            <app-async-image [src]="drink.imgUrl" [alt]="drink.name"></app-async-image>
           } @else {
             <p>No image available</p>
           }

--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -5,6 +5,7 @@ import {Drink, DrinkService} from '../services/drink.service';
 import {ModalService, ModalType} from '../services/modal.service';
 import {ErrorService} from '../services/error.service';
 import {NgForOf} from '@angular/common';
+import {AsyncImageComponent} from '../async-image/async-image.component';
 import {FpsService} from '../services/fps.service';
 import {StatisticsService} from '../services/statistics.service';
 
@@ -12,7 +13,8 @@ import {StatisticsService} from '../services/statistics.service';
   selector: 'app-home',
   imports: [
     FormsModule,
-    NgForOf
+    NgForOf,
+    AsyncImageComponent
   ],
   templateUrl: './home.component.html',
   standalone: true,


### PR DESCRIPTION
## Summary
- add `AsyncImageComponent` to show a spinner until images have loaded
- integrate `AsyncImageComponent` into Drinks and Home pages

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e055d6d08322a7a242ff172ea2f3