### PR TITLE
Improve drink loading UX

### DIFF
--- a/Frontend/src/app/app.component.ts
+++ b/Frontend/src/app/app.component.ts
@@ -75,7 +75,7 @@ export class AppComponent {
 
   async ngOnInit() {
     await this.ingredientService.loadIngredients();
-    await this.drinkService.loadDrinks();
+    void this.drinkService.loadDrinks();
     this.router.events.subscribe(event => {
       if (event instanceof NavigationStart) {
         this.modalService.closeAll();

--- a/Frontend/src/app/drinks/drinks.component.css
+++ b/Frontend/src/app/drinks/drinks.component.css
@@ -12,6 +12,11 @@
   text-align: center;
 }
 
+.loading-note {
+  font-style: italic;
+  margin-bottom: 1rem;
+}
+
 .drink-grid {
   display: flex;
   flex-wrap: wrap;

--- a/Frontend/src/app/drinks/drinks.component.html
+++ b/Frontend/src/app/drinks/drinks.component.html
@@ -17,6 +17,7 @@
   </div>
 
   <div id="drinks-section">
+    <p class="loading-note" *ngIf="loading()">Loading drinks...</p>
     @if(filteredDrinks().length > 0) {
     <!-- Available Drinks -->
     <h2>Available Drinks</h2>
@@ -25,7 +26,7 @@
         <div *ngIf="drink.available" class="drink-card" (click)="openModal(ModalType.EditDrink,drink)">
           <div class="drink-card-image-container">
             @if (drink.imgUrl) {
-              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
+              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name" loading="lazy">
             } @else {
               <p>No image available</p>
             }
@@ -56,7 +57,7 @@
         <div *ngIf="!drink.available" class="drink-card manage" (click)="openModal(ModalType.EditDrink,drink)">
           <div class="drink-card-image-container">
             @if (drink.imgUrl) {
-              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
+              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name" loading="lazy">
             } @else {
               <p>No image available</p>
             }

--- a/Frontend/src/app/drinks/drinks.component.ts
+++ b/Frontend/src/app/drinks/drinks.component.ts
@@ -22,6 +22,7 @@ export class DrinksComponent {
   private readonly modalService = inject(ModalService);
   private readonly errorService = inject(ErrorService);
   protected readonly ModalType = ModalType;
+  protected readonly loading = this.drinkService.loading;
 
   filteredDrinks = signal<Drink[]>([]);
   searchQuery: string = '';

--- a/Frontend/src/app/home/home.component.css
+++ b/Frontend/src/app/home/home.component.css
@@ -160,6 +160,11 @@ video {
   justify-content: center;
 }
 
+.loading-note {
+  font-style: italic;
+  margin-bottom: 1rem;
+}
+
 #slide-container{
   display: flex;
   position: relative;

--- a/Frontend/src/app/home/home.component.html
+++ b/Frontend/src/app/home/home.component.html
@@ -47,7 +47,7 @@
                [class.hidden]="getSlideState($index) === 'hidden'">
             <div class="drink-card-image-container">
             @if(drink.imgUrl) {
-              <img src="{{drink.imgUrl}}" alt="{{drink.name}}">
+              <img src="{{drink.imgUrl}}" alt="{{drink.name}}" loading="lazy">
             } @else {
               <p>No image available</p>
             }
@@ -75,12 +75,13 @@
     </select>
     <button class="button submit-btn" (click)="openModal(ModalType.CustomOrder)">Mix your own</button>
   </div>
+  <p class="loading-note" *ngIf="loading()">Loading drinks...</p>
   <div id="filtered-drinks">
     @for(drink of filteredDrinks(); track $index) {
       <div class="drink-card" (click)="openModal(ModalType.Order, drink)">
         <div class="drink-card-image-container">
           @if(drink.imgUrl) {
-            <img src="{{drink.imgUrl}}" alt="{{drink.name}}">
+            <img src="{{drink.imgUrl}}" alt="{{drink.name}}" loading="lazy">
           } @else {
             <p>No image available</p>
           }

--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -33,6 +33,7 @@ export class HomeComponent {
   lowEndDetected = this.fpsService.lowEndDetected;
   searchQuery: string = '';
   selectedIngredient: string = '';
+  loading = this.drinkService.loading;
 
   constructor() {
     effect(() => {

--- a/Frontend/src/app/services/drink.service.ts
+++ b/Frontend/src/app/services/drink.service.ts
@@ -1,9 +1,10 @@
 import {inject, Injectable, signal, WritableSignal} from '@angular/core';
 import {firstValueFrom, Observable} from 'rxjs';
-import {HttpClient, HttpErrorResponse, HttpResponse} from '@angular/common/http';
+import {HttpClient, HttpErrorResponse, HttpResponse, HttpContext} from '@angular/common/http';
 import {ErrorService} from './error.service';
 import {UserService} from './user.service';
 import {BASE_URL} from '../app.config';
+import {SKIP_LOADING} from './loading.interceptor';
 
 export interface DrinkBase {
   name: string;
@@ -28,12 +29,21 @@ export class DrinkService {
   private readonly userService =inject(UserService);
   private apiBaseUrl = inject(BASE_URL);
   drinks: WritableSignal<Drink[]> = signal([]);
+  loading = signal(false);
 
   async loadDrinks() {
+    this.loading.set(true);
     try {
-      this.drinks.set(await firstValueFrom(this.httpClient.get<Drink[]>(this.apiBaseUrl + "/drinks")));
+      const context = new HttpContext().set(SKIP_LOADING, true);
+      this.drinks.set(
+        await firstValueFrom(
+          this.httpClient.get<Drink[]>(this.apiBaseUrl + "/drinks", { context })
+        )
+      );
     } catch (e) {
       console.error(`An error occurred while loading drinks.`, e);
+    } finally {
+      this.loading.set(false);
     }
   }
 

--- a/Frontend/src/app/services/loading.interceptor.ts
+++ b/Frontend/src/app/services/loading.interceptor.ts
@@ -1,10 +1,15 @@
-import { HttpInterceptorFn, HttpRequest, HttpHandlerFn } from '@angular/common/http';
+import { HttpInterceptorFn, HttpRequest, HttpHandlerFn, HttpContextToken } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { finalize } from 'rxjs';
 import { LoadingService } from './loading.service';
 
+export const SKIP_LOADING = new HttpContextToken<boolean>(() => false);
+
 export const loadingInterceptor: HttpInterceptorFn = (req: HttpRequest<unknown>, next: HttpHandlerFn) => {
   const service = inject(LoadingService);
+  if (req.context.get(SKIP_LOADING)) {
+    return next(req);
+  }
   service.start();
   return next(req).pipe(finalize(() => service.stop()));
 };


### PR DESCRIPTION
## Summary
- allow skipping the global loading spinner per request
- use this for loading drinks so the UI isn't blocked
- show local loading messages on drinks and home pages
- lazy load drink images

## Testing
- `npx ng build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e055d6d08322a7a242ff172ea2f3