### PR TITLE
Lazy image loading for drinks

### DIFF
--- a/Frontend/src/app/drinks/drinks.component.html
+++ b/Frontend/src/app/drinks/drinks.component.html
@@ -25,7 +25,7 @@
         <div *ngIf="drink.available" class="drink-card" (click)="openModal(ModalType.EditDrink,drink)">
           <div class="drink-card-image-container">
             @if (drink.imgUrl) {
-              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
+              <app-lazy-image [src]="drink.imgUrl" [alt]="drink.name"></app-lazy-image>
             } @else {
               <p>No image available</p>
             }
@@ -56,7 +56,7 @@
         <div *ngIf="!drink.available" class="drink-card manage" (click)="openModal(ModalType.EditDrink,drink)">
           <div class="drink-card-image-container">
             @if (drink.imgUrl) {
-              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
+              <app-lazy-image [src]="drink.imgUrl" [alt]="drink.name"></app-lazy-image>
             } @else {
               <p>No image available</p>
             }

--- a/Frontend/src/app/drinks/drinks.component.ts
+++ b/Frontend/src/app/drinks/drinks.component.ts
@@ -2,6 +2,7 @@ import {Component, computed, effect, inject, signal} from '@angular/core';
 import {Drink, DrinkService} from '../services/drink.service';
 import {FormsModule} from '@angular/forms';
 import {NgForOf, NgIf} from '@angular/common';
+import {LazyImageComponent} from '../lazy-image/lazy-image.component';
 import {Ingredient, IngredientsService} from '../services/ingredients.service';
 import {ModalService, ModalType} from '../services/modal.service';
 import {ErrorService} from '../services/error.service';
@@ -11,7 +12,9 @@ import {ErrorService} from '../services/error.service';
   imports: [
     FormsModule,
     NgForOf,
-    NgIf],
+    NgIf,
+    LazyImageComponent
+  ],
   templateUrl: './drinks.component.html',
   standalone: true,
   styleUrl: './drinks.component.css'

--- a/Frontend/src/app/home/home.component.html
+++ b/Frontend/src/app/home/home.component.html
@@ -47,7 +47,7 @@
                [class.hidden]="getSlideState($index) === 'hidden'">
             <div class="drink-card-image-container">
             @if(drink.imgUrl) {
-              <img src="{{drink.imgUrl}}" alt="{{drink.name}}">
+              <app-lazy-image [src]="drink.imgUrl" [alt]="drink.name"></app-lazy-image>
             } @else {
               <p>No image available</p>
             }
@@ -80,7 +80,7 @@
       <div class="drink-card" (click)="openModal(ModalType.Order, drink)">
         <div class="drink-card-image-container">
           @if(drink.imgUrl) {
-            <img src="{{drink.imgUrl}}" alt="{{drink.name}}">
+            <app-lazy-image [src]="drink.imgUrl" [alt]="drink.name"></app-lazy-image>
           } @else {
             <p>No image available</p>
           }

--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -5,6 +5,7 @@ import {Drink, DrinkService} from '../services/drink.service';
 import {ModalService, ModalType} from '../services/modal.service';
 import {ErrorService} from '../services/error.service';
 import {NgForOf} from '@angular/common';
+import {LazyImageComponent} from '../lazy-image/lazy-image.component';
 import {FpsService} from '../services/fps.service';
 import {StatisticsService} from '../services/statistics.service';
 
@@ -12,7 +13,8 @@ import {StatisticsService} from '../services/statistics.service';
   selector: 'app-home',
   imports: [
     FormsModule,
-    NgForOf
+    NgForOf,
+    LazyImageComponent
   ],
   templateUrl: './home.component.html',
   standalone: true,

--- a/Frontend/src/app/lazy-image/lazy-image.component.css
+++ b/Frontend/src/app/lazy-image/lazy-image.component.css
@@ -1,0 +1,34 @@
+.lazy-image-wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.lazy-image-wrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.lazy-image-wrapper img.loaded {
+  opacity: 1;
+}
+
+.placeholder {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #eee;
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.5; }
+  100% { opacity: 1; }
+}

--- a/Frontend/src/app/lazy-image/lazy-image.component.html
+++ b/Frontend/src/app/lazy-image/lazy-image.component.html
@@ -1,0 +1,4 @@
+<div class="lazy-image-wrapper">
+  <img [src]="src" [alt]="alt" (load)="onLoad()" [class.loaded]="loaded" loading="lazy" />
+  <div class="placeholder" *ngIf="!loaded"></div>
+</div>

--- a/Frontend/src/app/lazy-image/lazy-image.component.ts
+++ b/Frontend/src/app/lazy-image/lazy-image.component.ts
@@ -1,0 +1,16 @@
+import {Component, Input} from '@angular/core';
+
+@Component({
+  selector: 'app-lazy-image',
+  standalone: true,
+  templateUrl: './lazy-image.component.html',
+  styleUrl: './lazy-image.component.css'
+})
+export class LazyImageComponent {
+  @Input() src: string = '';
+  @Input() alt: string = '';
+  loaded = false;
+  onLoad() {
+    this.loaded = true;
+  }
+}

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
@@ -3,7 +3,7 @@
     <div id="drink-overview">
       @if (selectedDrink()?.imgUrl) {
       <div class="modal-image">
-        <img [src]="selectedDrink()!.imgUrl" alt="Drink Image" class="drink-image" />
+        <app-lazy-image [src]="selectedDrink()!.imgUrl" alt="Drink Image"></app-lazy-image>
       </div>
       }
       <div id="modal-ingredient-list">

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.ts
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.ts
@@ -1,5 +1,6 @@
 import {Component, inject, signal, Signal, WritableSignal} from '@angular/core';
 import {NgForOf} from "@angular/common";
+import {LazyImageComponent} from '../../lazy-image/lazy-image.component';
 import {GenericModalComponent} from '../generic-modal/generic-modal.component';
 import {Drink, DrinkService} from '../../services/drink.service';
 import {ModalService, ModalType} from '../../services/modal.service';
@@ -11,7 +12,8 @@ import {FormsModule} from '@angular/forms';
   imports: [
     NgForOf,
     GenericModalComponent,
-    FormsModule
+    FormsModule,
+    LazyImageComponent
   ],
   templateUrl: './order-drink-modal.component.html',
   standalone: true,

--- a/Frontend/src/app/services/drink.service.ts
+++ b/Frontend/src/app/services/drink.service.ts
@@ -1,6 +1,6 @@
 import {inject, Injectable, signal, WritableSignal} from '@angular/core';
 import {firstValueFrom, Observable} from 'rxjs';
-import {HttpClient, HttpErrorResponse, HttpResponse} from '@angular/common/http';
+import {HttpClient, HttpErrorResponse, HttpResponse, HttpHeaders} from '@angular/common/http';
 import {ErrorService} from './error.service';
 import {UserService} from './user.service';
 import {BASE_URL} from '../app.config';
@@ -31,7 +31,12 @@ export class DrinkService {
 
   async loadDrinks() {
     try {
-      this.drinks.set(await firstValueFrom(this.httpClient.get<Drink[]>(this.apiBaseUrl + "/drinks")));
+      const headers = new HttpHeaders({ 'X-Skip-Loading': 'true' });
+      this.drinks.set(
+        await firstValueFrom(
+          this.httpClient.get<Drink[]>(this.apiBaseUrl + "/drinks", { headers })
+        )
+      );
     } catch (e) {
       console.error(`An error occurred while loading drinks.`, e);
     }

--- a/Frontend/src/app/services/loading.interceptor.ts
+++ b/Frontend/src/app/services/loading.interceptor.ts
@@ -5,6 +5,10 @@ import { LoadingService } from './loading.service';
 
 export const loadingInterceptor: HttpInterceptorFn = (req: HttpRequest<unknown>, next: HttpHandlerFn) => {
   const service = inject(LoadingService);
+  if (req.headers.has('X-Skip-Loading')) {
+    const modReq = req.clone({ headers: req.headers.delete('X-Skip-Loading') });
+    return next(modReq);
+  }
   service.start();
   return next(req).pipe(finalize(() => service.stop()));
 };


### PR DESCRIPTION
## Summary
- add `LazyImageComponent` with a placeholder to show while images load
- use `LazyImageComponent` in drink and home pages and in the order drink modal
- bypass the global loading spinner for drink images using a custom header
- update `loadingInterceptor` to respect the new header

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e055d6d08322a7a242ff172ea2f3