### PR TITLE
Refine frontend layout and styling

### DIFF
--- a/Frontend/src/app/app.component.css
+++ b/Frontend/src/app/app.component.css
@@ -1,176 +1,192 @@
-/*Nav bar*/
+/* Navigation */
 #navbar {
-  display:flex;
-  align-items: center;
-  background: var(--nav-bg);
-  color: white;
-  filter: drop-shadow(0px 0px 20px rgba(0, 0, 0, 0.35));
-  z-index: 3;
   position: sticky;
-  padding: 10px 30px 10px 20px;
-  gap: 20px;
-  box-sizing: border-box;
-  transition: all 0.5s ease;
+  top: 0;
+  width: 100%;
+  z-index: 10;
+  background: rgba(8, 34, 49, 0.85);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.15);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+#navbar.home {
+  background: linear-gradient(90deg, rgba(8, 34, 49, 0.65), rgba(12, 61, 84, 0.65));
+  box-shadow: none;
+}
+
+.nav-content {
+  max-width: 1300px;
+  margin: 0 auto;
+  padding: 12px 20px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  position: relative;
+}
+
+#menu-toggle {
+  display: none;
+  border: none;
+  background: transparent;
+  color: #f5f8fb;
+  font-size: 1.8rem;
+  cursor: pointer;
+  border-radius: 12px;
+  padding: 8px 10px;
+}
+
+#menu-toggle:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: #f5f8fb;
+  font-family: var(--primary-font), serif;
+  letter-spacing: 0.5px;
+}
+
+.brand-text {
+  font-size: 1.4rem;
 }
 
 #logo {
-  height: 100px;
+  height: 72px;
+  width: auto;
   cursor: pointer;
+  filter: drop-shadow(0 5px 12px rgba(0, 0, 0, 0.25));
 }
 
-.link{
-  font-size: 32px;
-  font-family: JosefinSans,sans-serif;
-  text-decoration: none;
-  color: var(--body-bg);
-  font-weight: lighter;
-}
-
-.bigLink{
-  font-size: 32px;
-  font-weight: bold;
-  color: var(--order-btn-bg);
-}
-
-#nav-page-container{
+#nav-page-container {
   display: flex;
-  gap: 20px;
-  width: 100%;
   align-items: center;
-  transition: max-height 0.3s ease;
+  gap: 18px;
+  margin-left: 10px;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
 }
 
-.active {
-  text-decoration: underline;
-  text-decoration-thickness: 2px;
+.bigLink,
+.link {
+  font-size: 1.1rem;
+  font-family: var(--default-font), sans-serif;
+  text-decoration: none;
+  color: #dfeffc;
+  padding: 10px 14px;
+  border-radius: 12px;
+  transition: color 0.25s ease, background 0.25s ease, transform 0.25s ease;
+}
+
+.bigLink {
+  font-weight: 700;
+  background: linear-gradient(135deg, #ffb56b, #fc5d5b);
+  color: #0c1824;
+  box-shadow: 0 10px 25px rgba(252, 93, 91, 0.25);
+}
+
+.link.light {
+  color: #dfeffc;
+}
+
+.link:hover,
+.bigLink:hover,
+.link.active {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateY(-1px);
 }
 
 #account-toggle {
   margin-left: auto;
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--nav-overlay-bg);
-}
-
-#account-toggle {
-  min-width: 60px;
-  min-height: 60px;
-  border-radius: 50% !important;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.08));
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  min-width: 56px;
+  min-height: 56px;
+  border-radius: 18px !important;
+  padding: 6px 10px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+  transition: transform 0.25s ease, background 0.25s ease, box-shadow 0.25s ease;
 }
 
 #account-toggle p {
-  font-size: 20px;
-  color: var(--body-bg);
+  font-size: 1.1rem;
+  color: #f5f8fb;
   letter-spacing: 2px;
-  font-weight: 1000;
-  margin: 4px 0 0 1px;
-}
-#menu-toggle {
-  display: none;
-  justify-self: end;
-  background: none;
-  border: none;
-  color: var(--body-bg);
-  font-size: 2rem;
-  cursor: pointer;
+  font-weight: 800;
+  margin: 0;
 }
 
-@media screen and (max-width: 1000px) {
+#account-toggle:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
+}
+
+@media screen and (max-width: 1040px) {
   #logo {
-    height: 80px;
+    height: 64px;
   }
 
-  .link, .bigLink {
-    font-size: 28px;
-  }
-}
-
-@media screen and (max-width: 800px) {
-  .link, .bigLink {
-    font-size: 26px;
-  }
-}
-
-@media screen and (max-width: 768px) {
   #nav-page-container {
-    display: none;
-    flex-direction: column;
-    width: 100%;
-    gap: 5px;
-    overflow: hidden;
-    max-height: 0;
+    gap: 12px;
   }
-  #nav-page-container.open {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
-    max-height: 500px;
-  }
-  .link,
-  .bigLink {
-    background: var(--nav-overlay-bg);
-    padding: 8px 20px;
-    max-width: 120px;
-    border-radius: 5px;
-    text-align: start;
-    font-size: 24px;
-  }
+}
 
+@media screen and (max-width: 820px) {
   #menu-toggle {
     display: block;
-    width: 60px;
   }
-  #navbar.home {
-    background: transparent;
-    position: absolute;
-  }
-  #navbar {
-    width: 100%;
-    padding: 15px 20px;
-    height: auto;
-    flex-wrap: wrap;
-    gap: 15px;
-    justify-content: space-between;
-  }
+
   #nav-page-container {
-    order: 3;
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    padding: 10px 18px 16px;
+    background: rgba(8, 34, 49, 0.96);
+    box-shadow: 0 15px 30px rgba(0, 0, 0, 0.2);
+    border-radius: 0 0 16px 16px;
+    flex-wrap: wrap;
+    justify-content: center;
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
   }
 
-  #account-toggle {
-    background: var(--nav-overlay-bg);
-    margin: 0;
-  }
-}
-
-@media screen and (max-width: 440px) {
-  #navbar.open {
-      background: var(--nav-bg);
-      position: sticky;
-      width: 100%;
-      transition: none;
-    }
-  }
-
-@media screen and (max-width: 300px) {
-  #logo {
-    display: none;
+  #nav-page-container.open {
+    max-height: 320px;
+    opacity: 1;
   }
 
   .link,
   .bigLink {
-    width: 100%;
-    max-width: 80%;
-  }
-
-  #nav-page-container.open {
-    flex-direction: column;
+    width: calc(50% - 14px);
     text-align: center;
   }
 
   #account-toggle {
-    margin-left: auto;
+    min-width: 52px;
+    min-height: 52px;
+  }
+}
+
+@media screen and (max-width: 520px) {
+  .nav-content {
+    padding: 12px 14px;
+  }
+
+  .link,
+  .bigLink {
+    width: 100%;
+  }
+
+  #navbar.home {
+    position: absolute;
   }
 }

--- a/Frontend/src/app/app.component.html
+++ b/Frontend/src/app/app.component.html
@@ -1,52 +1,56 @@
 <nav id="navbar" [ngClass]="{open: menuOpen, home: isAtHomeScreen()}" #navbar>
-  <button id="menu-toggle" (click)="toggleMenu()">☰</button>
-  <img src="assets/images/InconV2png.png" id="logo" alt="Logo" routerLink="home">
-  <div id="nav-page-container" [ngClass]="{open: menuOpen}">
-    <a class="bigLink" routerLink="home">
-      Home
+  <div class="nav-content">
+    <button id="menu-toggle" type="button" (click)="toggleMenu()" aria-label="Toggle navigation">
+      ☰
+    </button>
+    <a class="brand" routerLink="home" aria-label="Go to start page">
+      <img src="assets/images/InconV2png.png" id="logo" alt="Hula Swirl logo">
+      <span class="brand-text">Hula Swirl</span>
     </a>
-    <a class="link" [ngClass]="{light: !menuOpen}"
-       *ngIf="userService.hasRole('admin')"
-       routerLink="drinks"
-       routerLinkActive="active">
-      Drinks
-    </a>
-    <a class="link" [ngClass]="{light: !menuOpen}"
-       *ngIf="userService.hasRole('admin')"
-       routerLink="ingredients"
-       routerLinkActive="active">
-      Ingredients
-    </a>
-
-    <a class="link" [ngClass]="{light: !menuOpen}"
-       *ngIf="userService.hasRole('admin')"
-       routerLink="statistics"
-       routerLinkActive="active">
-      Statistics
-    </a>
-    <a class="link" [ngClass]="{light: !menuOpen}"
-       *ngIf="userService.hasRole('operator')"
-       routerLink="orders"
-       routerLinkActive="active">
-      Orders
-    </a>
-    <a class="link" [ngClass]="{light: !menuOpen}"
-       *ngIf="userService.hasRole('admin')"
-       routerLink="users"
-       routerLinkActive="active">
-      Users
-    </a>
-  </div>
-  <div id="account-toggle" [ngClass]="{light: !menuOpen}" (click)="userInitials() ? openAccountModal() : openLoginModal()">
-  @if(userInitials()) {
-    <p class="noselect">{{userInitials()}}</p>
-  } @else {
-    <p>🦩</p>
-  }
+    <div id="nav-page-container" [ngClass]="{open: menuOpen}">
+      <a class="bigLink" routerLink="home">Home</a>
+      <a class="link" [ngClass]="{light: !menuOpen}"
+         *ngIf="userService.hasRole('admin')"
+         routerLink="drinks"
+         routerLinkActive="active">
+        Drinks
+      </a>
+      <a class="link" [ngClass]="{light: !menuOpen}"
+         *ngIf="userService.hasRole('admin')"
+         routerLink="ingredients"
+         routerLinkActive="active">
+        Ingredients
+      </a>
+      <a class="link" [ngClass]="{light: !menuOpen}"
+         *ngIf="userService.hasRole('admin')"
+         routerLink="statistics"
+         routerLinkActive="active">
+        Statistics
+      </a>
+      <a class="link" [ngClass]="{light: !menuOpen}"
+         *ngIf="userService.hasRole('operator')"
+         routerLink="orders"
+         routerLinkActive="active">
+        Orders
+      </a>
+      <a class="link" [ngClass]="{light: !menuOpen}"
+         *ngIf="userService.hasRole('admin')"
+         routerLink="users"
+         routerLinkActive="active">
+        Users
+      </a>
+    </div>
+    <button id="account-toggle" type="button" [ngClass]="{light: !menuOpen}" (click)="userInitials() ? openAccountModal() : openLoginModal()">
+      @if(userInitials()) {
+        <p class="noselect">{{userInitials()}}</p>
+      } @else {
+        <p>🦩</p>
+      }
+    </button>
   </div>
 </nav>
 
-<app-background-leaves>
+<app-background-leaves class="page-shell">
   <router-outlet></router-outlet>
   <app-order-custom-drink-modal id="order-custom-drink-modal" [hidden]="displayedModal() != ModalType.CustomOrder"></app-order-custom-drink-modal>
   <app-order-drink-modal id="order-drink-modal" [hidden]="displayedModal() != ModalType.Order"></app-order-drink-modal>

--- a/Frontend/src/app/app.component.ts
+++ b/Frontend/src/app/app.component.ts
@@ -6,8 +6,7 @@ import {
   ViewChild,
   ElementRef,
   effect,
-  signal,
-  WritableSignal
+  signal
 } from '@angular/core';
 import {Router, NavigationStart, RouterLink, RouterLinkActive, RouterOutlet} from '@angular/router';
 import {NgIf, NgClass} from '@angular/common';
@@ -23,7 +22,6 @@ import {StatusModalComponent} from './modals/status-modal/status-modal.component
 import {LoadingSpinnerComponent} from './loading-spinner/loading-spinner.component';
 import {BackgroundLeavesComponent} from './background-leaves/background-leaves.component';
 import {AccountModalComponent} from './modals/account-modal/account-modal.component';
-import {FpsService} from './services/fps.service';
 
 @Component({
   selector: 'app-root',
@@ -34,13 +32,13 @@ import {FpsService} from './services/fps.service';
     OrderDrinkModalComponent,
     DrinkModalComponent,
     RouterLinkActive,
-    UserModalComponent,
-    NgIf,
-    NgClass,
-    StatusModalComponent,
-    LoadingSpinnerComponent,
-    BackgroundLeavesComponent,
-    AccountModalComponent
+  UserModalComponent,
+  NgIf,
+  NgClass,
+  StatusModalComponent,
+  LoadingSpinnerComponent,
+  BackgroundLeavesComponent,
+  AccountModalComponent
   ],
   templateUrl: './app.component.html',
   standalone: true,

--- a/Frontend/src/app/drinks/drinks.component.css
+++ b/Frontend/src/app/drinks/drinks.component.css
@@ -1,25 +1,31 @@
 #drinks-page {
-  width: 90%;
-  margin: 0 auto;
+  width: 100%;
+  box-sizing: border-box;
 }
 
-.filter-container {
-  width: 95%;
-  margin: 30px auto;
+.section-subheader {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
 }
 
 #drinks-section {
-  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 26px;
 }
 
 .drink-grid {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.9rem;
-  justify-items: start;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 14px;
 }
 
 .drink-name {
   font-weight: bold;
+}
+
+@media screen and (max-width: 640px) {
+  #drinks-page { padding: 18px; }
 }

--- a/Frontend/src/app/drinks/drinks.component.html
+++ b/Frontend/src/app/drinks/drinks.component.html
@@ -1,72 +1,77 @@
-<div id="drinks-page">
-    <div class="filter-container">
-      <input
-        type="text"
-        placeholder="🔍 Search for a drink..."
-        [(ngModel)]="searchQuery"
-        (input)="filterDrinks()"
-        class="form-input"
-      />
-      <select [(ngModel)]="selectedIngredient" (change)="filterDrinks()" class="form-input">
-        <option value="">All Ingredients</option>
-        <option *ngFor="let ingredient of getUniqueIngredients()" [value]="ingredient">
-          {{ ingredient }}
-        </option>
-      </select>
-      <button class="button submit-btn" (click)="openModal(ModalType.AddDrink)">Add Drink</button>
+<section id="drinks-page" class="container section">
+  <div class="section-header">
+    <div>
+      <p class="eyebrow">Manage menu</p>
+      <h2>Drinks</h2>
+      <p class="section-subtitle">Search, filter and update available recipes.</p>
+    </div>
+    <button class="button primary" (click)="openModal(ModalType.AddDrink)">Add Drink</button>
+  </div>
+
+  <div class="filter-container">
+    <input
+      type="text"
+      placeholder="🔍 Search for a drink..."
+      [(ngModel)]="searchQuery"
+      (input)="filterDrinks()"
+      class="form-input"
+      aria-label="Search for a drink"
+    />
+    <select [(ngModel)]="selectedIngredient" (change)="filterDrinks()" class="form-input" aria-label="Filter by ingredient">
+      <option value="">All Ingredients</option>
+      <option *ngFor="let ingredient of getUniqueIngredients()" [value]="ingredient">
+        {{ ingredient }}
+      </option>
+    </select>
   </div>
 
   <div id="drinks-section">
     @if(filteredDrinks().length > 0) {
-    <!-- Available Drinks -->
-    <h2>Available Drinks</h2>
-    <div id="available-drinks" class="drink-grid">
-      @for (drink of filteredDrinks(); track $index){
-        <div *ngIf="drink.available" class="drink-card" (click)="openModal(ModalType.EditDrink,drink)">
-          <div class="drink-card-image-container">
-            @if (drink.imgUrl) {
-              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
-            } @else {
-              <p>No image available</p>
-            }
-          </div>
-          <p class="drink-name">{{ drink.name }}</p>
+      <div class="drink-section">
+        <div class="section-subheader">
+          <h3>Available Drinks</h3>
+          <p>Visible to guests and ready to order.</p>
         </div>
-      }
-    </div>
+        <div id="available-drinks" class="drink-grid">
+          @for (drink of filteredDrinks(); track $index){
+            <div *ngIf="drink.available" class="drink-card" (click)="openModal(ModalType.EditDrink,drink)">
+              <div class="drink-card-image-container">
+                @if (drink.imgUrl) {
+                  <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
+                } @else {
+                  <p>No image available</p>
+                }
+              </div>
+              <p class="drink-name">{{ drink.name }}</p>
+            </div>
+          }
+        </div>
+      </div>
 
-    <!-- Hidden Drinks
-    <h2>Hidden Drinks</h2>
-    <div id="D_HiddenDrinks" class="D_DrinksContainer">
-      @for (drink of filteredDrinks(); track $index){
-        <div class="D_Drink" (click)="openModal(ModalType.ED,drink)">
-          <div class="D_imgContainer">
-            <img class="D_img" [src]="drink.imgUrl" [alt]="drink.name">
-          </div>
-          <p class="D_DrinkText">{{ drink.name }}</p>
+      <div class="drink-section">
+        <div class="section-subheader">
+          <h3>Hidden Drinks</h3>
+          <p>Keep recipes organized even when they are not in rotation.</p>
         </div>
-      }
-    </div>
-    -->
-
-    <!-- Not Available Drinks -->
-    <h2>Hidden Drinks</h2>
-    <div id="unavailable-drinks" class="drink-grid">
-      @for (drink of filteredDrinks(); track $index){
-        <div *ngIf="!drink.available" class="drink-card manage" (click)="openModal(ModalType.EditDrink,drink)">
-          <div class="drink-card-image-container">
-            @if (drink.imgUrl) {
-              <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
-            } @else {
-              <p>No image available</p>
-            }
-          </div>
-          <p class="drink-name">{{ drink.name }}</p>
+        <div id="unavailable-drinks" class="drink-grid">
+          @for (drink of filteredDrinks(); track $index){
+            <div *ngIf="!drink.available" class="drink-card manage" (click)="openModal(ModalType.EditDrink,drink)">
+              <div class="drink-card-image-container">
+                @if (drink.imgUrl) {
+                  <img class="drink-image" [src]="drink.imgUrl" [alt]="drink.name">
+                } @else {
+                  <p>No image available</p>
+                }
+              </div>
+              <p class="drink-name">{{ drink.name }}</p>
+            </div>
+          }
         </div>
-      }
-    </div>
+      </div>
     } @else {
-      <h3>There aren't any drinks yet</h3>
+      <div class="empty-state">
+        <p>There aren't any drinks yet. Add a recipe to get started.</p>
+      </div>
     }
   </div>
-</div>
+</section>

--- a/Frontend/src/app/home/home.component.css
+++ b/Frontend/src/app/home/home.component.css
@@ -1,229 +1,242 @@
-:root {
-  --primary-color: #2c3e50;
+#landing.hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  gap: 32px;
+  padding: 60px 10% 40px;
+  background: linear-gradient(135deg, #0f2d3c 0%, #16606f 50%, #f5ae66 100%);
+  overflow: hidden;
+  isolation: isolate;
+  min-height: 70vh;
 }
 
-#landing {
-  width: 100%;
-  background: linear-gradient(180deg, rgba(22,85,111,1) 0%, rgba(60,148,148,1) 53%, rgba(85,206,180,1) 67%, rgba(248,210,127,1) 81%, rgba(248,210,127,1) 84%, rgba(242,145,99,1) 90%, rgba(239,109,89,1) 96%);
-  filter: drop-shadow(0px 0px 5px rgba(47, 10, 10, 0.69)) saturate(110%);
-  display:flex;
-  align-items: center;
+.gradient-overlay {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.12), transparent 35%),
+  radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.16), transparent 30%),
+  radial-gradient(circle at 60% 75%, rgba(255, 255, 255, 0.14), transparent 35%);
+  z-index: 0;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  color: #fefefe;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px 12px;
+}
+
+.hero-content h1 {
+  font-size: clamp(2rem, 3vw, 3.4rem);
+  margin: 0;
+  line-height: 1.1;
+}
+
+.subtitle {
+  font-size: 1.1rem;
+  color: #e9f6ff;
+  margin: 0;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-weight: 800;
+  font-size: 0.85rem;
+  color: #ffd89b;
+  margin: 0;
+}
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.pill {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  font-size: 0.95rem;
+}
+
+.button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 6px;
+}
+
+.hero-visual {
+  position: relative;
+  z-index: 1;
+  display: flex;
   justify-content: center;
-  gap: 50px;
+  align-items: center;
+}
+
+.visual-frame {
+  position: relative;
+  width: 100%;
+  max-width: 520px;
+  aspect-ratio: 4 / 5;
+  border-radius: 22px;
   overflow: hidden;
-  height: 70vh;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.06));
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.bgVideo {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  mix-blend-mode: screen;
 }
 
 #drink-showcase {
-  z-index: -1;
-  height: 85%;
+  position: absolute;
+  inset: 10% 8% auto auto;
+  width: 85%;
+  height: auto;
+  z-index: 1;
+  filter: drop-shadow(0px 20px 30px rgba(0,0,0,0.35));
 }
 
 .leaves {
   position: absolute;
   height: 100%;
+  width: auto;
   z-index: 0;
-  right: 0;
-  filter: drop-shadow(0px 15px 4px rgba(0, 0, 0, 0.42));
+  filter: drop-shadow(0px 15px 4px rgba(0, 0, 0, 0.32));
 }
 
-.bgVideo {
-  object-fit: cover;
-  z-index: -1;
-  background-color: rgb(44, 97, 121); /* optional fallback */
-  background-size: contain;
-  width: 100%;
-  height: 370px;
-}
-video {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: auto;
-  z-index: -1;
-  mix-blend-mode: lighten; /* oder 'screen', je nach Effekt */
-  background-color: #00FF00; /* der Greenscreen aus deinem Video */
-  pointer-events: none;
-}
+.leaves.left { left: -15%; top: -5%; }
+.leaves.right { right: -18%; top: -10%; }
 
-.leaves:first-child {
-  left: 0;
-}
-
-#landing-text {
-  margin-top: 10px
-}
-
-#landing-text > * {
-  color:#fefde6;
-  filter: drop-shadow(0px 0px 5px rgba(10, 17, 47, 0.75));
-  line-height: 1.2;
-}
-
-#landing-title {
-  font-size: 50px;
-  margin-left: 10px;
-  font-weight: bold;
-}
-
-#landing-subtitle {
-  font-size: 25px;
-  margin-top: 24px;
-  font-weight: lighter;
-}
-
-#recommendations {
-  text-align: center;
-}
-
-#button-container {
-  display: flex;
-  gap: 20px;
-  margin-top: 40px;
-}
-
-#button-container .button{
-  border-radius: 100px;
-  border: 3px solid var(--order-btn-bg);
-  padding: 15px;
-  filter: drop-shadow(0px 0px 5px rgba(0, 0, 0, 0.01));
-}
-
-#order-button {
-  background: var(--order-btn-bg);
-}
-
-#order-custom-button {
-  color:var(--order-btn-bg);
-}
-
-@media screen and (max-width: 830px) {
-  #drink-showcase {
-    display: none;
-    z-index: 2;
-  }
-
-  .leaves:first-child {
-    left: calc(-200px + 20%);
-  }
-
-  .leaves {
-    right: calc(-200px + 20%);
-  }
-
-  #landing {
-    justify-content: center;
-    padding: 50px 0;
-  }
-
-  #landing-text {
-    text-align: center;
-    scale: 0.9 !important;
-  }
-
-  #button-container {
-    justify-content: center;
-    flex-wrap: wrap;
-  }
-}
-
-@media screen and (max-width: 1440px) {
-  .leaves:first-child {
-    left: calc(-200px + 10%);
-  }
-
-  .leaves {
-    right: calc(-200px + 10%);
-  }
-
-  #landing-text, #drink-showcase {
-    scale: 0.95;
-  }
-
-  #landing {
-    gap: 0;
-  }
-}
-
-.bodyBackground {
-  position: relative;
-  overflow: hidden;
-  display: flex;
-  align-items: center;
-}
-
-#recommendations, #all-drinks {
+.section {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  gap: 20px;
 }
 
-#slide-container{
+.section-header {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.section-subtitle {
+  margin: 4px 0 0;
+  color: var(--primary-font-color);
+}
+
+.slider-controls {
+  display: flex;
+  gap: 8px;
+}
+
+.icon-button {
+  border: 1px solid var(--element-primary-outline);
+  background: #fff;
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  font-size: 1.2rem;
+  color: var(--primary-font-color);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 10px 18px rgba(0,0,0,0.08);
+}
+
+.icon-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  box-shadow: none;
+}
+
+.icon-button:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 22px rgba(0,0,0,0.12);
+}
+
+#slide-container {
   display: flex;
   position: relative;
   justify-content: center;
   align-items: center;
+  width: 100%;
 }
 
 #slide-track {
   display: flex;
   justify-content: center;
   align-items: center;
-  position: relative;
+  gap: 20px;
+  flex-wrap: wrap;
 }
 
-.slide-track-arrow {
-  background: none;
-  border: none;
-  font-size: 2rem;
-  cursor: pointer;
-  color: var(--primary-color);
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 10;
-  filter: drop-shadow(5px 5px 3px rgba(68, 47, 36, 0.32));
-  font-weight: bold;
-}
-.drink-card.slide-neighbour {
-  opacity: 0.8;
-  transform: scale(0.9);
-  z-index: 2;
-}
-.drink-card.slide-neighbour:hover{
-  transform: scale(93%);
+#recommendations {
+  text-align: center;
 }
 
-@media screen and (max-width: 1000px) {
-  #slide-container {
-    scale: 0.9;
-  }
-}
-@media screen and (max-width: 900px) {
-  #slide-container {
-    scale: 1;
-  }
-  .drink-card.slide-neighbour {
-    display: none;
-  }
-}
-
-#arrow-left {
-  left: -40px;
-}
-#arrow-right {
-  right: -40px;
-}
-.slide-track-arrow:disabled {
-  color: var(--element-primary-outline);
-  cursor: not-allowed;
-}
+.drink-card.slide-neighbour { opacity: 0.9; transform: scale(0.96); z-index: 2; }
+.drink-card.slide-neighbour:hover{ transform: scale(0.98); }
 
 #filtered-drinks {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+  width: 100%;
+}
+
+.empty-state {
+  padding: 18px;
+  border-radius: 14px;
+  background: var(--ingredient-bg-color);
+  width: 100%;
+  text-align: center;
+  color: var(--heavy-font-color);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+}
+
+@media screen and (max-width: 980px) {
+  #landing.hero {
+    padding: 50px 6% 30px;
+  }
+
+  .visual-frame {
+    max-width: 460px;
+  }
+
+  .leaves.left { left: -25%; }
+  .leaves.right { right: -28%; }
+}
+
+@media screen and (max-width: 720px) {
+  #landing.hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .hero-content { align-items: center; }
+  .button-group { justify-content: center; }
+  .pill-row { justify-content: center; }
+  .leaves.left { left: -40%; }
+  .leaves.right { right: -45%; }
+}
+
+@media screen and (max-width: 520px) {
+  .visual-frame { max-width: 360px; }
 }

--- a/Frontend/src/app/home/home.component.html
+++ b/Frontend/src/app/home/home.component.html
@@ -1,92 +1,115 @@
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-
-<div id="landing">
-  <img alt="Leaves" src="assets/images/sideLeafsLeft.png" class="leaves">
-  <img alt="Leaves" src="assets/images/sideLeafs.png" class="leaves">
-  @if(!lowEndDetected()) {
-    <video autoplay loop muted playsinline class="bgVideo"  style=" transform:  scaleY(1) rotate(180deg)">
-      <source src="assets/images/stargif/stars.webm" type="video/webm" />
-    </video>
-  }
-  <!--
-  <div class="stars-wrapper">
-    <video autoplay loop muted playsinline class="bgVideo normal">
-      <source src="assets/images/stargif/stars.webm" type="video/webm" />
-    </video>
-    <video autoplay loop muted playsinline class="bgVideo mirrored">
-      <source src="assets/images/stargif/stars.webm" type="video/webm" />
-    </video>
-  </div>-->
-
-
-  <div id="landing-text">
-    <div id="landing-title">
-      Make your perfect<br>summer drinks<br> with Hula Swirl!
+<section id="landing" class="hero">
+  <div class="gradient-overlay"></div>
+  <div class="hero-content">
+    <p class="eyebrow">Tropical robotic bar</p>
+    <h1>Make your perfect summer drinks with Hula Swirl</h1>
+    <p class="subtitle">Mix it easy, mix it smart, mix it fast – ideal for every moment.</p>
+    <div class="pill-row">
+      <span class="pill">Fresh ingredients</span>
+      <span class="pill">Smart pump routing</span>
+      <span class="pill">Queue-friendly ordering</span>
     </div>
-    <div id="landing-subtitle">
-      Mix it easy, mix it smart, mix it fast,<br> ideal for every moment
-    </div>
-    <div id="button-container">
-      <button (click)="scrollToElement()" class="button" id="order-button">ORDER NOW</button>
-      <button (click)="openModal(ModalType.CustomOrder)" class="button" id="order-custom-button">MIX YOUR OWN</button>
+    <div class="button-group">
+      <button type="button" (click)="scrollToElement()" class="button primary">Order now</button>
+      <button type="button" (click)="openModal(ModalType.CustomOrder)" class="button ghost">Mix your own</button>
     </div>
   </div>
-  <img alt="Drink" src="assets/images/DrinkImage.png" id="drink-showcase">
+  <div class="hero-visual">
+    <div class="visual-frame">
+      @if(!lowEndDetected()) {
+        <video autoplay loop muted playsinline class="bgVideo" aria-hidden="true">
+          <source src="assets/images/stargif/stars.webm" type="video/webm" />
+        </video>
+      }
+      <img alt="Signature drink" src="assets/images/DrinkImage.png" id="drink-showcase">
+      <img alt="Decorative leaves" src="assets/images/sideLeafsLeft.png" class="leaves left">
+      <img alt="Decorative leaves" src="assets/images/sideLeafs.png" class="leaves right">
+    </div>
+  </div>
+</section>
+
+<section class="container section" id="recommendations" #targetElement>
+  <div class="section-header">
+    <div>
+      <p class="eyebrow">Curated by data</p>
+      <h2>Our recommendations</h2>
+      <p class="section-subtitle">Popular drinks crafted from what is currently available.</p>
+    </div>
+    <div class="slider-controls">
+      <button class="icon-button" id="arrow-left" (click)="prevSlide()" [disabled]="isPrevDisabled()" aria-label="Previous recommendation">&#8249;</button>
+      <button class="icon-button" id="arrow-right" (click)="nextSlide()" [disabled]="isNextDisabled()" aria-label="Next recommendation">&#8250;</button>
+    </div>
   </div>
 
-<div class="container" id="recommendations" #targetElement>
-  <h2>Our recommendations</h2>
+  @if(recommendedDrinks().length > 0) {
   <div id="slide-container">
-      <button class="slide-track-arrow" id="arrow-left" (click)="prevSlide()" [disabled]="isPrevDisabled()" [class.disabled]="isPrevDisabled()">&#8249;</button>
-      <div id="slide-track">
-        @for (drink of recommendedDrinks(); track $index) {
-          <div class="drink-card"
-               (click)="openModal(ModalType.Order, drink)"
-               [class.slide-focus]="getSlideState($index) === 'focus'"
-               [class.slide-neighbour]="getSlideState($index) === 'neighbour'"
-               [class.hidden]="getSlideState($index) === 'hidden'">
-            <div class="drink-card-image-container">
+    <div id="slide-track">
+      @for (drink of recommendedDrinks(); track $index) {
+        <div class="drink-card"
+             (click)="openModal(ModalType.Order, drink)"
+             [class.slide-focus]="getSlideState($index) === 'focus'"
+             [class.slide-neighbour]="getSlideState($index) === 'neighbour'"
+             [class.hidden]="getSlideState($index) === 'hidden'">
+          <div class="drink-card-image-container">
             @if(drink.imgUrl) {
-              <img src="{{drink.imgUrl}}" alt="{{drink.name}}">
+              <img [src]="drink.imgUrl" [alt]="drink.name">
             } @else {
               <p>No image available</p>
             }
-            </div>
-            <p>{{ drink.name }}</p>
           </div>
-        }
-      </div>
-      <button class="slide-track-arrow" id="arrow-right" (click)="nextSlide()" [disabled]="isNextDisabled()" [class.disabled]="isNextDisabled()">&#8250;</button>
+          <p>{{ drink.name }}</p>
+        </div>
+      }
+    </div>
   </div>
-</div>
-<div class="container" id="all-drinks">
-  <h2>All Drinks</h2>
+  } @else {
+    <div class="empty-state">
+      <p>Recommendations will appear as soon as drinks are available.</p>
+    </div>
+  }
+</section>
+
+<section class="container section" id="all-drinks">
+  <div class="section-header">
+    <div>
+      <p class="eyebrow">Browse everything</p>
+      <h2>All Drinks</h2>
+      <p class="section-subtitle">Filter by ingredient or search to find your next favorite.</p>
+    </div>
+    <button type="button" class="button primary" (click)="openModal(ModalType.CustomOrder)">Mix your own</button>
+  </div>
   <div class="filter-container">
     <input
       type="text"
       placeholder="🔍 Search for a drink..."
       [(ngModel)]="searchQuery"
-      (input)="filterDrinksByQuery()"
+      (input)="applyFilters()"
       class="form-input"
+      aria-label="Search drinks"
     />
-    <select [(ngModel)]="selectedIngredient" (change)="filterDrinksByIngredients()" class="form-input">
+    <select [(ngModel)]="selectedIngredient" (change)="applyFilters()" class="form-input" aria-label="Filter by ingredient">
       <option value="">All Ingredients</option>
       <option *ngFor="let ingredient of getUniqueIngredients()" [value]="ingredient">{{ ingredient }}</option>
     </select>
-    <button class="button submit-btn" (click)="openModal(ModalType.CustomOrder)">Mix your own</button>
   </div>
-  <div id="filtered-drinks">
-    @for(drink of filteredDrinks(); track $index) {
-      <div class="drink-card" (click)="openModal(ModalType.Order, drink)">
-        <div class="drink-card-image-container">
-          @if(drink.imgUrl) {
-            <img src="{{drink.imgUrl}}" alt="{{drink.name}}">
-          } @else {
-            <p>No image available</p>
-          }
+  <div id="filtered-drinks" class="drink-grid">
+    @if(filteredDrinks().length > 0) {
+      @for(drink of filteredDrinks(); track $index) {
+        <div class="drink-card" (click)="openModal(ModalType.Order, drink)">
+          <div class="drink-card-image-container">
+            @if(drink.imgUrl) {
+              <img [src]="drink.imgUrl" [alt]="drink.name">
+            } @else {
+              <p>No image available</p>
+            }
+          </div>
+          <p>{{ drink.name }}</p>
         </div>
-        <p>{{ drink.name }}</p>
+      }
+    } @else {
+      <div class="empty-state">
+        <p>No drinks match your filters yet. Try clearing the filters or check back soon.</p>
       </div>
     }
   </div>
-</div>
+</section>

--- a/Frontend/src/app/home/home.component.ts
+++ b/Frontend/src/app/home/home.component.ts
@@ -3,7 +3,6 @@ import {Ingredient, IngredientsService} from '../services/ingredients.service';
 import {FormsModule} from '@angular/forms';
 import {Drink, DrinkService} from '../services/drink.service';
 import {ModalService, ModalType} from '../services/modal.service';
-import {ErrorService} from '../services/error.service';
 import {NgForOf} from '@angular/common';
 import {FpsService} from '../services/fps.service';
 import {StatisticsService} from '../services/statistics.service';
@@ -28,7 +27,7 @@ export class HomeComponent {
   allAvailableDrinks = signal<Drink[]>([]);
   allAvailableIngredients = signal<Ingredient[]>([]);
   recommendedDrinks = signal<Drink[]>([]);
-  filteredDrinks = signal<Drink[]>(this.allAvailableDrinks());
+  filteredDrinks = signal<Drink[]>([]);
   currentSlideIdx = signal(0);
   lowEndDetected = this.fpsService.lowEndDetected;
   searchQuery: string = '';
@@ -36,18 +35,27 @@ export class HomeComponent {
 
   constructor() {
     effect(() => {
-      this.allAvailableIngredients.set(this.ingredientService.ingredients().filter(ing => ing.pumpSlot !== null));
-      this.allAvailableDrinks.set(this.drinkService.drinks().filter(drink =>
+      const availableIngredients = this.ingredientService.ingredients().filter(ing => ing.pumpSlot !== null);
+      this.allAvailableIngredients.set(availableIngredients);
+
+      const availableDrinks = this.drinkService.drinks().filter(drink =>
         drink.available &&
-        drink.drinkIngredients.every(ing => this.allAvailableIngredients().some(availableIng => availableIng.ingredientName === ing.ingredientName))
-      ));
-      this.filteredDrinks.set(this.allAvailableDrinks());
+        drink.drinkIngredients.every(ing =>
+          this.allAvailableIngredients().some(availableIng => availableIng.ingredientName === ing.ingredientName)
+        )
+      );
+
+      this.allAvailableDrinks.set(availableDrinks);
+      this.applyFilters();
+
       const top5drinkNames = this.statisticsService.drinkStats().slice(0, 5).map(stat => stat.drinkName);
-      if(top5drinkNames.length > 0) {
+      if (top5drinkNames.length > 0) {
         this.recommendedDrinks.set(this.allAvailableDrinks().filter(drink => top5drinkNames.includes(drink.name)));
       } else {
         this.recommendedDrinks.set(this.allAvailableDrinks().slice(0, 5));
       }
+
+      this.currentSlideIdx.set(0);
     });
   }
 
@@ -57,15 +65,17 @@ export class HomeComponent {
 
   @ViewChild('targetElement', { static: false }) targetElement!: ElementRef;
   scrollToElement() {
-    this.targetElement.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'start',alignToTop:true });
+    this.targetElement.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'start', alignToTop: true });
   }
 
   nextSlide(): void {
+    if(this.recommendedDrinks().length < 2) return;
     if(this.currentSlideIdx() < this.recommendedDrinks().length - 1) {
       this.currentSlideIdx.set(this.currentSlideIdx() + 1);
     }
   }
   prevSlide(): void {
+    if(this.recommendedDrinks().length < 2) return;
     if (this.currentSlideIdx() > 0) {
       this.currentSlideIdx.set(this.currentSlideIdx() - 1);
     }
@@ -75,6 +85,7 @@ export class HomeComponent {
     const totalSlides = this.recommendedDrinks().length;
     const previousIndex = (this.currentSlideIdx() - 1 + totalSlides) % totalSlides;
     const nextIndex = (this.currentSlideIdx() + 1) % totalSlides;
+    if (totalSlides === 0) return 'hidden';
     if (index === this.currentSlideIdx()) return 'focus';
     if (
       this.currentSlideIdx() > 0 && this.currentSlideIdx() < totalSlides - 1 &&
@@ -86,30 +97,23 @@ export class HomeComponent {
   }
 
   isPrevDisabled(): boolean {
-    return this.currentSlideIdx() === 0;
+    return this.currentSlideIdx() === 0 || this.recommendedDrinks().length < 2;
   }
   isNextDisabled(): boolean {
-    return this.currentSlideIdx() >= this.recommendedDrinks().length - 1;
+    return this.recommendedDrinks().length < 2 || this.currentSlideIdx() >= this.recommendedDrinks().length - 1;
   }
 
-  filterDrinksByQuery() {
-    this.filteredDrinks.set(
-      this.allAvailableDrinks().filter(drink =>
-        drink.name.toLowerCase().includes(this.searchQuery.toLowerCase())
-      )
-    );
-  }
+  applyFilters() {
+    const query = this.searchQuery.trim().toLowerCase();
+    const selected = this.selectedIngredient;
 
-  filterDrinksByIngredients() {
-    if (this.selectedIngredient) {
-      this.filteredDrinks.set(
-        this.allAvailableDrinks().filter(drink =>
-          drink.drinkIngredients.some(ing => ing.ingredientName === this.selectedIngredient)
-        )
-      );
-    } else {
-      this.filteredDrinks.set(this.allAvailableDrinks());
-    }
+    const filtered = this.allAvailableDrinks().filter(drink => {
+      const matchesQuery = !query || drink.name.toLowerCase().includes(query);
+      const matchesIngredient = !selected || drink.drinkIngredients.some(ing => ing.ingredientName === selected);
+      return matchesQuery && matchesIngredient;
+    });
+
+    this.filteredDrinks.set(filtered);
   }
 
   getUniqueIngredients(): string[] {

--- a/Frontend/src/styles.css
+++ b/Frontend/src/styles.css
@@ -1,5 +1,5 @@
 :root {
-  --body-bg: #faeee1;
+  --body-bg: #f8f3ec;
   --nav-bg: #0e2d3e;
   --nav-overlay-bg: rgba(21, 60, 81, 0.65);
   --popup-bg: #f4e3cd;
@@ -7,15 +7,15 @@
   --ingredient-bg-color: #f4f3f2;
   --ingredient-quantity-bg-color: #f1e1c3;
   --ingredient-selected-bg-color: #eeffe4;
-  --element-primary-outline: #cacaca;
+  --element-primary-outline: #d7d7d7;
   --active-bg: #c3ffac;
   --inactive-bg: #ff9898;
   --cancel-btn-bg: #df6b6b;
   --order-btn-bg: #fc5d5b;
-  --sunset-gradient: linear-gradient(to bottom right, rgb(255, 194, 108) 0%, rgb(255, 125, 114) 100%);
-  --sunrise-gradient: linear-gradient(to bottom right, #f65a5a 0%, #ffd15e 100%);
+  --sunset-gradient: linear-gradient(135deg, #ffb56b 0%, #fc5d5b 100%);
+  --sunrise-gradient: linear-gradient(135deg, #f65a5a 0%, #ffd15e 100%);
   --primary-font-color: #575757;
-  --heavy-font-color: #3f3f3f;
+  --heavy-font-color: #2e2e2e;
   --form-input-bg-yellow: #fdfded;
 
   --default-font: 'JosefinSans';
@@ -33,21 +33,10 @@ h1, h2, h3, h4 {
   font-family: var(--primary-font), serif;
 }
 
-h1 {
-  font-size: 2.5rem;
-}
-
-h2 {
-  font-size: 2rem;
-}
-
-h3 {
-  font-size: 1.5rem;
-}
-
-h4 {
-  font-size: 1.25rem;
-}
+h1 { font-size: 2.5rem; }
+h2 { font-size: 2rem; }
+h3 { font-size: 1.5rem; }
+h4 { font-size: 1.25rem; }
 
 p, span, label, input, textarea, select {
   color: var(--primary-font-color);
@@ -56,23 +45,16 @@ p, span, label, input, textarea, select {
 }
 
 .noselect {
-  -webkit-touch-callout: none; /* iOS Safari */
-  -webkit-user-select: none; /* Safari */
-  -moz-user-select: none; /* Old versions of Firefox */
-  -ms-user-select: none; /* Internet Explorer/Edge */
-  user-select: none; /* Non-prefixed version, currently */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
-body::-webkit-scrollbar {
-  display: none;
-}
-html::-webkit-scrollbar {
-  display: none;
-}
-
-html{
-  scroll-behavior: smooth;
-}
+body::-webkit-scrollbar { display: none; }
+html::-webkit-scrollbar { display: none; }
+html{ scroll-behavior: smooth; }
 
 @font-face {
   font-family: 'Katibeh';
@@ -96,54 +78,79 @@ html{
 }
 
 .container {
-  padding: 20px 12%;
+  padding: 24px clamp(16px, 6vw, 12%);
+  box-sizing: border-box;
+}
+
+.section-header {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+
+.section-subtitle {
+  margin: 4px 0 0;
+  color: var(--primary-font-color);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-weight: 800;
+  font-size: 0.85rem;
+  color: #ff8d62;
+  margin: 0;
+}
+
+.section {
+  background: #ffffff;
+  border-radius: 18px;
+  box-shadow: 0 16px 40px rgba(0,0,0,0.08);
+  margin: 28px auto;
 }
 
 .button {
-  background-color: #fdfded;
   border: none;
-  color: white;
-  padding: 10px 20px;
+  color: #0f1c2b;
+  padding: 12px 18px;
   text-align: center;
   text-decoration: none;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-size: 16px;
   cursor: pointer;
-  border-radius: 10px;
-  transition: 0.3s;
-  filter:saturate(200%);
+  border-radius: 12px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
   height: 100%;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08);
+  background: #fff;
+  font-weight: 700;
 }
 
-.button:disabled {
-  cursor: not-allowed;
-  filter: saturate(100%);
-}
-
-.button:hover:not(:disabled) {
-  scale: 1.05;
-}
-
-.cancel-btn {
-  background-color: var(--cancel-btn-bg);
-}
-
-.submit-btn {
+.button.primary {
   background: var(--sunset-gradient);
+  color: #1a1a1a;
 }
 
-.checkbox-container {
-  box-sizing: border-box;
-  display: flex;
-  align-items: center;
+.button.ghost {
+  background: transparent;
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.7);
+  box-shadow: none;
 }
 
-.checkbox-container label {
-  padding-top: 4px;
-  cursor: pointer;
-}
+.button:disabled { cursor: not-allowed; opacity: 0.6; }
+.button:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 12px 26px rgba(0, 0, 0, 0.12); }
 
+.cancel-btn { background-color: var(--cancel-btn-bg); color: #fff; }
+.submit-btn { background: var(--sunset-gradient); color: #1a1a1a; }
+
+.checkbox-container { box-sizing: border-box; display: flex; align-items: center; }
+.checkbox-container label { padding-top: 4px; cursor: pointer; }
 .checkbox-container input {
   appearance: none;
   min-width: 20px;
@@ -174,84 +181,45 @@ html{
   box-sizing: border-box;
   background-color: var(--form-input-bg-yellow);
   border: 1px solid var(--element-primary-outline);
-  border-radius: 5px;
-  padding: 5px 10px;
+  border-radius: 10px;
+  padding: 10px 12px;
   height: 100%;
   outline: none;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.05);
 }
 
 .form-input::-webkit-outer-spin-button,
-.form-input::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}
-
-/* Firefox */
-.form-input[type=number] {
-  -moz-appearance: textfield;
-}
+.form-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+.form-input[type=number] { -moz-appearance: textfield; }
 
 /* Scrollbar */
-::-webkit-scrollbar {
-  width: 5px;
-  height: 5px;
-}
-
-::-webkit-scrollbar-track {
-  background: linear-gradient(#f65a5a 0%, #ffd15e 100%);
-  border-radius: 5px;
-}
-
-::-webkit-scrollbar-thumb {
-  background: #d34b4b;
-  border-radius: 5px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: #c43a3a;
-}
+::-webkit-scrollbar { width: 5px; height: 5px; }
+::-webkit-scrollbar-track { background: linear-gradient(#f65a5a 0%, #ffd15e 100%); border-radius: 5px; }
+::-webkit-scrollbar-thumb { background: #d34b4b; border-radius: 5px; }
+::-webkit-scrollbar-thumb:hover { background: #c43a3a; }
 
 /* Drink filter */
 .filter-container {
   max-width: 1200px;
   width: 100%;
-  display: flex;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   align-items: center;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-bottom: 25px;
+  gap: 12px;
+  margin-bottom: 18px;
 }
 
-.filter-container > * {
-  box-sizing: border-box;
-  height: 45px;
-}
-
-.filter-container button {
-  font-weight: bold;
-  border: none !important;
-  border-radius: 20px;
-}
-
-.filter-container input {
-  flex: 1;
-  padding: 10px;
+.filter-container > * { box-sizing: border-box; height: 45px; }
+.filter-container button { font-weight: bold; border-radius: 14px; border: none !important; }
+.filter-container input,
+.filter-container select {
   font-size: 1rem;
   background: linear-gradient(#F6F6F6, #F6F6F6) padding-box, var(--sunrise-gradient) border-box;
-  border-radius: 15px;
+  border-radius: 12px;
   border: 3px solid transparent;
 }
-
 .filter-container select {
-  padding: 10px;
-  font-size: 1rem;
   cursor: pointer;
-  background: linear-gradient(#F6F6F6, #F6F6F6) padding-box,
-  var(--sunrise-gradient) border-box;
-  border-radius: 15px;
-  border: 3px solid transparent;
   -moz-appearance: none;
   -webkit-appearance: none;
   appearance: none;
@@ -261,17 +229,17 @@ html{
 .drink-card {
   text-align: center;
   margin: 0;
-  transition: transform 0.5s ease, opacity 0.5s ease;
+  transition: transform 0.3s ease, opacity 0.3s ease, box-shadow 0.3s ease;
   display: flex;
   flex-direction: column;
   align-items: center;
   overflow: hidden;
-  background: linear-gradient(#F6F6F6, #F6F6F6) padding-box,
-  linear-gradient(to bottom right, #ea6b52 , #f5d273) border-box;
-  border-radius: 15px;
+  background: linear-gradient(#ffffff, #ffffff) padding-box,
+  linear-gradient(to bottom right, #f7c08e , #f79595) border-box;
+  border-radius: 18px;
   border: 4px solid transparent;
-  filter: drop-shadow(0px 0px 10px rgba(68, 47, 36, 0.25)) saturate(110%);
-  padding: 0;
+  filter: drop-shadow(0px 0px 10px rgba(68, 47, 36, 0.15));
+  padding: 10px;
   cursor: pointer;
 }
 
@@ -281,6 +249,9 @@ html{
   display: flex;
   justify-content: center;
   align-items: center;
+  background: #fff;
+  border-radius: 14px;
+  overflow: hidden;
 }
 
 .drink-card-image-container img {
@@ -289,12 +260,8 @@ html{
   object-fit: cover;
 }
 
-.drink-card.hidden {
-  display: none;
-}
-.drink-card:hover{
-  transform: scale(103%);
-}
+.drink-card.hidden { display: none; }
+.drink-card:hover{ transform: translateY(-3px); box-shadow: 0 16px 30px rgba(0,0,0,0.12); }
 
 .drink-card p:not(.drink-card-image-container > p) {
   font-weight: bold;
@@ -306,75 +273,25 @@ html{
   font-size: 20px;
 }
 
-.error {
-  margin: 0;
-  color: red !important;
-  font-weight: lighter !important;
-}
+.error { margin: 0; color: red !important; font-weight: lighter !important; }
+.field-error { font-size: 14px !important; }
+.global-error { font-size: 16px !important; margin: 0.5rem 0; }
 
-.field-error {
-  font-size: 14px !important;
-}
+.identity { display: flex; margin-bottom: 20px; }
+.identity > * { margin: 0; }
+.row { display: flex; align-items: center; flex-wrap: wrap; gap: 5px; padding: 4px 0; }
+.badge { border-radius: 3px; padding: 8px 5px 5px; margin-top: 4px !important; }
+.system { color: #ffffff; background: #000000; }
+.admin { color: #8c3131; background: #ffa1a1; }
+.operator { color: #458c31; background: #caffb8; }
+.user { color: #4c4ca5; background: #ceceff; }
 
-.global-error {
-  font-size: 16px !important;
-  margin: 0.5rem 0;
-}
-
-.identity {
-  display: flex;
-  margin-bottom: 20px;
-}
-
-.identity > * {
-  margin: 0;
-}
-
-.row {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 5px;
-  padding: 4px 0;
-}
-
-.badge {
-  border-radius: 3px;
-  padding: 8px 5px 5px;
-  margin-top: 4px !important;
-}
-
-.system {
-  color: #ffffff;
-  background: #000000;
-}
-
-.admin {
-  color: #8c3131;
-  background: #ffa1a1;
-}
-
-.operator {
-  color: #458c31;
-  background: #caffb8;
-}
-
-.user {
-  color: #4c4ca5;
-  background: #ceceff;
+@media screen and (max-width: 900px) {
+  .drink-card-image-container { width: 180px; height: 180px; }
 }
 
 @media screen and (max-width: 550px) {
-  .container {
-    padding: 20px 5%;
-  }
-
-  .drink-card-image-container {
-    width: 150px;
-    height: 150px;
-  }
-
-  .drink-card p:not(.drink-card-image-container > p) {
-    font-size: 16px;
-  }
+  .container { padding: 18px 5%; }
+  .drink-card-image-container { width: 150px; height: 150px; }
+  .drink-card p:not(.drink-card-image-container > p) { font-size: 16px; }
 }


### PR DESCRIPTION
## Summary
- modernize navigation and shared styling to better match the refreshed theme and mobile behavior
- refresh the home page hero, recommendations carousel, and drink filtering UX for clarity
- streamline the drinks management page layout with consistent cards and empty states

## Testing
- Not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931387367008322858ec52762ebbcbd)