### PR TITLE
Refactor modals to shared dialog shell

### DIFF
--- a/Frontend/docs/modal-refactor.md
+++ b/Frontend/docs/modal-refactor.md
@@ -1,0 +1,155 @@
+# Unified modal system
+
+This project now uses a single `<dialog>`-powered shell (`app-generic-modal`) and a service-driven API (`ModalService`) to render every modal with consistent chrome, behavior, and accessibility.
+
+## Architecture overview
+- **Modal shell (`app-generic-modal`)** – owns the `<dialog>` element, header (title/subtitle/icon), close affordances (X button, ESC, optional backdrop click), scrollable body, and footer/button area. Supports projected content or `TemplateRef`-driven bodies/footers and emits `closed` when the dialog is dismissed.
+- **Modal host (`app-modal-host`)** – listens to the modal service and paints dynamic dialogs from configuration objects (title, message, template refs, button configs). It is mounted once in `app.component.html`.
+- **Modal service (`ModalService`)** – still exposes the legacy `openModal/closeModal` API for `ModalType` screens, and also adds a template-friendly `open(config)` method that accepts title/size/icon, `TemplateRef` content, footer button definitions, and backdrop/ESC flags. Focus is preserved when opening/closing, and the body is locked whenever any modal is active.
+
+## Core code
+### Modal shell (TypeScript)
+```ts
+// src/app/modals/generic-modal/generic-modal.component.ts
+@Input() title = '';
+@Input() subtitle?: string;
+@Input() icon?: ModalIcon;
+@Input() size: ModalSize = 'medium';
+@Input() closeOnEsc = true;
+@Input() closeOnBackdrop = true;
+@Input() bodyTemplate?: TemplateRef<GenericModalTemplateContext>;
+@Input() footerTemplate?: TemplateRef<GenericModalTemplateContext>;
+@Input() data: unknown = null;
+@Input() footerButtons: GenericModalButton[] = [];
+@Output() closed = new EventEmitter<void>();
+// Opens the native <dialog>, manages focus, handles ESC/backdrop, emits closed
+```
+
+### Modal shell (template)
+```html
+<!-- src/app/modals/generic-modal/generic-modal.component.html -->
+<dialog #dialog class="modal-dialog" ...>
+  <div class="modal-card">
+    <header class="modal-head"> ... close button ... </header>
+    <section class="modal-body">
+      <ng-container *ngIf="bodyTemplate; else projectedBody"
+                    [ngTemplateOutlet]="bodyTemplate"
+                    [ngTemplateOutletContext]="{ data: data, close: requestClose.bind(this) }">
+      </ng-container>
+      <ng-template #projectedBody>
+        <ng-content select="[modal-body]"></ng-content>
+      </ng-template>
+    </section>
+    <footer class="modal-footer">
+      <ng-container *ngIf="footerTemplate; else projectedFooter" ...></ng-container>
+      <ng-template #projectedFooter>
+        <ng-content select="[modal-footer]"></ng-content>
+        <div class="modal-buttons">
+          <ng-content select="[modal-buttons]"></ng-content>
+          <button *ngFor="let btn of footerButtons" ... (click)="handleButtonClick(btn)">{{ btn.label }}</button>
+        </div>
+      </ng-template>
+    </footer>
+  </div>
+</dialog>
+```
+
+### Modal service API
+```ts
+// src/app/services/modal.service.ts
+open<T>(config: ModalConfig<T>) {
+  const id = config.id ?? (globalThis.crypto?.randomUUID?.() ?? fallbackId);
+  const modal: ActiveModal<T> = {
+    id,
+    config: { size: 'medium', closeOnBackdrop: true, closeOnEsc: true, ...config },
+    restoreFocus: document.activeElement as HTMLElement | null,
+  };
+  this.dynamicModals.set([...this.dynamicModals(), modal]);
+  return { id, close: () => this.closeDynamic(id) };
+}
+```
+`ModalConfig` accepts `title`, `subtitle`, `icon`, `size`, `message`, `data`, `TemplateRef` body/footer, `footerButtons`, `closeOnEsc`, and `closeOnBackdrop`.
+
+### Modal host
+```html
+<!-- src/app/modals/modal-host/modal-host.component.html -->
+@for (modal of modals(); track modal.id) {
+  <app-generic-modal [title]="modal.config.title || 'Modal'" ... (closed)="modalService.closeDynamic(modal.id)">
+    <div modal-body *ngIf="!modal.config.bodyTemplate && modal.config.message" class="modal-message">
+      {{ modal.config.message }}
+    </div>
+  </app-generic-modal>
+}
+```
+Mount the host once in `app.component.html` (`<app-modal-host></app-modal-host>`).
+
+## Migration examples
+### Configure your own Drink (before → after)
+- **Before:** A bespoke modal frame in `order-custom-drink-modal.component.html` wrapped the form and buttons.
+- **After:** The same body lives inside the shared shell—only the inner form remains:
+```html
+<app-generic-modal title="Configure your own Drink" [size]="'large'" (closed)="closeModal()">
+  <div id="ingredient-list" modal-body> ... </div>
+  <div modal-footer> ... </div>
+  <div modal-buttons class="order-buttons"> ... </div>
+</app-generic-modal>
+```
+
+### Blue Lagoon details
+```html
+<app-generic-modal [title]="selectedDrink()?.name" [size]="'medium'" (closed)="closeModal()">
+  <div modal-body>
+    <div id="drink-overview"> <!-- image + ingredient list --> </div>
+    <div id="toppings"> ... </div>
+  </div>
+  <div modal-buttons>
+    <button class="button submit-btn" (click)="submitOrder()">Order</button>
+  </div>
+</app-generic-modal>
+```
+
+### Add/Edit Drink form
+```html
+<app-generic-modal [title]="getTitle()" [size]="'large'" (closed)="closeModal()">
+  <div modal-body>
+    <div class="modal-content"> <!-- upload + form fields + ingredient rows --> </div>
+  </div>
+  <div modal-buttons>
+    <button class="button cancel-btn" (click)="closeModal()">Cancel</button>
+    <button class="button submit-btn" (click)="save()">{{ saveLabel }}</button>
+  </div>
+</app-generic-modal>
+```
+
+### Simple Status alert
+```ts
+// Anywhere in a component
+const ref = this.modalService.open({
+  title: 'Status',
+  icon: 'info',
+  message: 'Your drink is queued!',
+  footerButtons: [{ label: 'OK', variant: 'primary' }]
+});
+```
+The modal host renders this using the shared shell automatically.
+
+## Adding a new modal (step-by-step)
+1. **Define any data model** you need in the calling component.
+2. **Create the body template** (if not just a message):
+   ```html
+   <ng-template #newDrinkTemplate let-data let-close="close">
+     <form (ngSubmit)="save(close)"> ... </form>
+   </ng-template>
+   ```
+3. **Open the modal via the service:**
+   ```ts
+   this.modalService.open({
+     title: 'Create Drink',
+     size: 'large',
+     bodyTemplate: this.newDrinkTemplate,
+     data: formModel,
+     footerButtons: [{ label: 'Cancel' }, { label: 'Save', variant: 'primary', action: () => this.save() }],
+   });
+   ```
+4. **Handle results/buttons:** use the `action` callbacks on `footerButtons` or call the `close` function provided in the template context.
+

--- a/Frontend/src/app/app.component.html
+++ b/Frontend/src/app/app.component.html
@@ -48,12 +48,19 @@
 
 <app-background-leaves>
   <router-outlet></router-outlet>
-  <app-order-custom-drink-modal id="order-custom-drink-modal" [hidden]="displayedModal() != ModalType.CustomOrder"></app-order-custom-drink-modal>
-  <app-order-drink-modal id="order-drink-modal" [hidden]="displayedModal() != ModalType.Order"></app-order-drink-modal>
-  <app-drink-modal id="drink-modal" [hidden]="displayedModal()!=ModalType.AddDrink && displayedModal()!=ModalType.EditDrink"></app-drink-modal>
-  <app-user-modal id="user-modal" [hidden]="displayedModal()!=ModalType.User"></app-user-modal>
-  <app-status-modal id="status-modal" [hidden]="displayedModal()!=ModalType.Status"></app-status-modal>
-  <app-account-modal id="account-modal" [hidden]="displayedModal()!=ModalType.Account"></app-account-modal>
+  <app-order-custom-drink-modal
+    id="order-custom-drink-modal"
+    *ngIf="displayedModal() === ModalType.CustomOrder"></app-order-custom-drink-modal>
+  <app-order-drink-modal
+    id="order-drink-modal"
+    *ngIf="displayedModal() === ModalType.Order"></app-order-drink-modal>
+  <app-drink-modal
+    id="drink-modal"
+    *ngIf="displayedModal()===ModalType.AddDrink || displayedModal()===ModalType.EditDrink"></app-drink-modal>
+  <app-user-modal id="user-modal" *ngIf="displayedModal()===ModalType.User"></app-user-modal>
+  <app-status-modal id="status-modal" *ngIf="displayedModal()===ModalType.Status"></app-status-modal>
+  <app-account-modal id="account-modal" *ngIf="displayedModal()===ModalType.Account"></app-account-modal>
 </app-background-leaves>
 
 <app-loading-spinner></app-loading-spinner>
+<app-modal-host></app-modal-host>

--- a/Frontend/src/app/app.component.ts
+++ b/Frontend/src/app/app.component.ts
@@ -24,6 +24,7 @@ import {LoadingSpinnerComponent} from './loading-spinner/loading-spinner.compone
 import {BackgroundLeavesComponent} from './background-leaves/background-leaves.component';
 import {AccountModalComponent} from './modals/account-modal/account-modal.component';
 import {FpsService} from './services/fps.service';
+import {ModalHostComponent} from './modals/modal-host/modal-host.component';
 
 @Component({
   selector: 'app-root',
@@ -40,7 +41,8 @@ import {FpsService} from './services/fps.service';
     StatusModalComponent,
     LoadingSpinnerComponent,
     BackgroundLeavesComponent,
-    AccountModalComponent
+    AccountModalComponent,
+    ModalHostComponent
   ],
   templateUrl: './app.component.html',
   standalone: true,

--- a/Frontend/src/app/modals/account-modal/account-modal.component.html
+++ b/Frontend/src/app/modals/account-modal/account-modal.component.html
@@ -1,5 +1,5 @@
 @if(userInfo()) {
-  <app-generic-modal title="My Account" (closed)="close()">
+  <app-generic-modal title="My Account" [size]="'small'" (closed)="close()">
     <div modal-body class="account-content">
       <div class="user-info">
           <div class="row identity">

--- a/Frontend/src/app/modals/drink-modal/drink-modal.component.html
+++ b/Frontend/src/app/modals/drink-modal/drink-modal.component.html
@@ -1,4 +1,4 @@
-<app-generic-modal [title]="mode() === 'add' ? 'Add Drink' : 'Edit Drink'" (closed)="closeModal()">
+<app-generic-modal [title]="mode() === 'add' ? 'Add Drink' : 'Edit Drink'" [size]="'large'" (closed)="closeModal()">
   <div modal-body>
     <div id="left-column">
       <div class="upload-box" [class.drag-over]="isDragging" (click)="fileInput.click()" (dragover)="onDragOver($event)" (dragleave)="onDragLeave($event)" (drop)="onDrop($event)">

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.css
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.css
@@ -1,78 +1,125 @@
-/* Modal */
-.modal-frame {
-  position: fixed;
-  z-index: 100;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  backdrop-filter: blur(1px);
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  justify-content: center;
-  align-items: center;
+.modal-dialog {
+  border: none;
+  padding: 0;
+  width: min(90vw, 720px);
+  background: transparent;
+  color: var(--primary-font-color);
+  overflow: visible;
 }
 
-.modal-form {
-  background-color: var(--popup-bg);
-  border-radius: 10px;
+.modal-card {
+  background: var(--popup-bg);
+  border-radius: 12px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  min-width: min(90vw, 320px);
+  max-width: 960px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
   padding: 20px;
-  max-width: 550px;
-  width: 80%;
-  box-shadow: 0 0 10px 3px rgb(64, 64, 64);
+}
+
+.modal-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(2px);
 }
 
 .modal-head {
   display: flex;
   justify-content: space-between;
-  gap: 20px;
-  color: var(--primary-font-color);
+  align-items: flex-start;
+  gap: 12px;
 }
 
-.modal-head h1 {
+.modal-headline {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.modal-titles h1 {
   margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
 }
 
-.close-modal-button {
-  font-size: 24px;
-  font-weight: bold;
-  height: 20px;
-  width: 20px;
-  text-align: center;
-  line-height: 24px;
-  transition: 0.3s transform ease;
-  margin: -7px -7px 0 0;
+.modal-subtitle {
+  margin: 0 0 4px;
+  opacity: 0.8;
+  font-size: 0.9rem;
 }
-.close-modal-button:after{
-  content: '✖';
-}
-.close-modal-button:hover {
-  cursor: pointer;
-  transform: rotate(10deg);
+
+.modal-icon::before {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 0.9rem;
+  content: attr(data-icon);
 }
 
 .modal-body {
-  margin: 15px 0;
-  max-height: 310px;
-  overflow-y: auto;
+  max-height: 60vh;
+  overflow: auto;
 }
 
 .modal-footer {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 20px;
+  flex-direction: column;
+  gap: 10px;
 }
 
-@media screen and (max-width: 650px) {
-  .modal-body {
-    max-height: 400px;
+.modal-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.close-modal-button {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.1rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 4px;
+  border-radius: 8px;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.close-modal-button:hover,
+.close-modal-button:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  transform: rotate(4deg);
+}
+
+.modal-small {
+  width: min(420px, 92vw);
+}
+
+.modal-medium {
+  width: min(620px, 94vw);
+}
+
+.modal-large {
+  width: min(860px, 96vw);
+}
+
+.modal-full {
+  width: min(1100px, 98vw);
+}
+
+@media (max-width: 600px) {
+  .modal-card {
+    padding: 16px;
+    gap: 10px;
   }
-}
-
-@media (max-width: 350px) {
-  .modal-form {
-    width: 85%;
-    padding: 15px;
+  .modal-body {
+    max-height: 70vh;
   }
 }

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.html
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.html
@@ -1,18 +1,50 @@
-<div class="modal-frame">
-  <div class="modal-form">
-    <div class="modal-head">
-      <h1>{{ title }}</h1>
-      <span class="close-modal-button" (click)="close()"></span>
-    </div>
-    <div class="modal-body">
-      <ng-content select="[modal-body]"></ng-content>
-    </div>
-    <div class="modal-footer">
-      <ng-content select="[modal-footer]"></ng-content>
-    </div>
-    <div class="modal-buttons">
-      <ng-content select="[modal-buttons]"></ng-content>
-      <button *ngFor="let btn of buttons" class="button" (click)="btn.action()">{{ btn.label }}</button>
-    </div>
+<dialog
+  #dialog
+  class="modal-dialog"
+  [class]="'modal-dialog ' + sizeClass"
+  (cancel)="onDialogCancel($event)"
+  (click)="onDialogClick($event)">
+  <div class="modal-card">
+    <header class="modal-head">
+      <div class="modal-headline">
+        <span *ngIf="icon" class="modal-icon" [attr.data-icon]="icon"></span>
+        <div class="modal-titles">
+          <p class="modal-subtitle" *ngIf="subtitle">{{ subtitle }}</p>
+          <h1>{{ title }}</h1>
+        </div>
+      </div>
+      <button class="close-modal-button" type="button" (click)="requestClose()" aria-label="Close dialog">✖</button>
+    </header>
+
+    <section class="modal-body">
+      <ng-container *ngIf="bodyTemplate; else projectedBody"
+                    [ngTemplateOutlet]="bodyTemplate"
+                    [ngTemplateOutletContext]="{ data: data, close: requestClose.bind(this) }">
+      </ng-container>
+      <ng-template #projectedBody>
+        <ng-content select="[modal-body]"></ng-content>
+      </ng-template>
+    </section>
+
+    <footer class="modal-footer" *ngIf="hasFooterContent">
+      <ng-container *ngIf="footerTemplate; else projectedFooter"
+                    [ngTemplateOutlet]="footerTemplate"
+                    [ngTemplateOutletContext]="{ data: data, close: requestClose.bind(this) }">
+      </ng-container>
+      <ng-template #projectedFooter>
+        <ng-content select="[modal-footer]"></ng-content>
+        <div class="modal-buttons" *ngIf="footerButtons.length > 0 || (projectedButtons?.length ?? 0) > 0">
+          <ng-content select="[modal-buttons]"></ng-content>
+          <button
+            *ngFor="let btn of footerButtons"
+            class="button"
+            [ngClass]="btn.variant ?? 'secondary'"
+            type="button"
+            (click)="handleButtonClick(btn)">
+            {{ btn.label }}
+          </button>
+        </div>
+      </ng-template>
+    </footer>
   </div>
-</div>
+</dialog>

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.ts
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.ts
@@ -1,29 +1,160 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  AfterViewInit,
+  ContentChildren,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  SimpleChanges,
+  TemplateRef,
+  ViewChild,
+  Directive,
+  QueryList
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ModalService } from '../../services/modal.service';
+
+export type ModalIcon = 'info' | 'success' | 'warning' | 'error' | undefined;
+export type ModalSize = 'small' | 'medium' | 'large' | 'full' | string;
 
 export interface GenericModalButton {
   label: string;
-  action: () => void;
+  action?: () => void;
+  variant?: 'primary' | 'secondary' | 'danger';
+  closeOnClick?: boolean;
 }
+
+export interface GenericModalTemplateContext<T = unknown> {
+  data: T | null;
+  close: () => void;
+}
+
+@Directive({ selector: '[modal-footer]' })
+export class ModalFooterProjection {}
+
+@Directive({ selector: '[modal-buttons]' })
+export class ModalButtonsProjection {}
 
 @Component({
   selector: 'app-generic-modal',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ModalFooterProjection, ModalButtonsProjection],
   templateUrl: './generic-modal.component.html',
   styleUrls: ['./generic-modal.component.css']
 })
-export class GenericModalComponent {
+export class GenericModalComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() title: string = '';
-  //@Input() imageUrl: string | null = null;
-  @Input() buttons: GenericModalButton[] = [];
+  @Input() subtitle?: string;
+  @Input() icon?: ModalIcon;
+  @Input() size: ModalSize = 'medium';
+  @Input() closeOnEsc: boolean = true;
+  @Input() closeOnBackdrop: boolean = true;
+  @Input() bodyTemplate?: TemplateRef<GenericModalTemplateContext>;
+  @Input() footerTemplate?: TemplateRef<GenericModalTemplateContext>;
+  @Input() data: unknown = null;
+  @Input() footerButtons: GenericModalButton[] = [];
+  @Input() opened: boolean = true;
+
   @Output() closed = new EventEmitter<void>();
 
-  constructor(private modalService: ModalService) {}
+  @ViewChild('dialog', { static: false }) dialog?: ElementRef<HTMLDialogElement>;
+  @ContentChildren(ModalFooterProjection, { descendants: true }) projectedFooters?: QueryList<ModalFooterProjection>;
+  @ContentChildren(ModalButtonsProjection, { descendants: true }) projectedButtons?: QueryList<ModalButtonsProjection>;
 
-  close() {
+  private previouslyFocused?: HTMLElement | null;
+
+  get hasFooterContent(): boolean {
+    const hasProjectedFooter = (this.projectedFooters?.length ?? 0) > 0;
+    const hasProjectedButtons = (this.projectedButtons?.length ?? 0) > 0;
+    return !!this.footerTemplate || this.footerButtons.length > 0 || hasProjectedFooter || hasProjectedButtons;
+  }
+
+  get sizeClass(): string {
+    if (['small', 'medium', 'large', 'full'].includes(this.size)) {
+      return `modal-${this.size}`;
+    }
+    return '';
+  }
+
+  ngAfterViewInit(): void {
+    if (this.opened) {
+      this.show();
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if ('opened' in changes && !changes['opened'].firstChange && this.dialog) {
+      if (this.opened) {
+        this.show();
+      } else {
+        this.requestClose();
+      }
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.dialog?.nativeElement?.open) {
+      this.dialog.nativeElement.close();
+    }
+  }
+
+  show() {
+    if (!this.dialog) return;
+    const element = this.dialog.nativeElement;
+    this.previouslyFocused = document.activeElement as HTMLElement;
+    if (!element.open) {
+      element.showModal();
+    }
+    const firstInput = element.querySelector<HTMLElement>('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    queueMicrotask(() => firstInput?.focus());
+  }
+
+  requestClose() {
+    if (!this.dialog) return;
+    if (this.dialog.nativeElement.open) {
+      this.dialog.nativeElement.close();
+    }
+    this.restoreFocus();
     this.closed.emit();
-    this.modalService.closeModal();
+  }
+
+  handleButtonClick(btn: GenericModalButton) {
+    btn.action?.();
+    if (btn.closeOnClick ?? true) {
+      this.requestClose();
+    }
+  }
+
+  onDialogCancel(event: Event) {
+    if (!this.closeOnEsc) {
+      event.preventDefault();
+      return;
+    }
+    event.preventDefault();
+    this.requestClose();
+  }
+
+  onDialogClick(event: MouseEvent) {
+    if (!this.closeOnBackdrop) return;
+    if (event.target === this.dialog?.nativeElement) {
+      this.requestClose();
+    }
+  }
+
+  private restoreFocus() {
+    if (this.previouslyFocused && document.body.contains(this.previouslyFocused)) {
+      this.previouslyFocused.focus({ preventScroll: true });
+    }
+  }
+
+  @HostListener('document:keydown.escape', ['$event'])
+  onEsc(event: KeyboardEvent) {
+    if (this.closeOnEsc && this.dialog?.nativeElement?.open) {
+      event.preventDefault();
+      this.requestClose();
+    }
   }
 }

--- a/Frontend/src/app/modals/modal-host/modal-host.component.css
+++ b/Frontend/src/app/modals/modal-host/modal-host.component.css
@@ -1,0 +1,15 @@
+:host {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 100;
+}
+
+app-generic-modal {
+  pointer-events: auto;
+}
+
+.modal-message {
+  margin: 0;
+  line-height: 1.5;
+}

--- a/Frontend/src/app/modals/modal-host/modal-host.component.html
+++ b/Frontend/src/app/modals/modal-host/modal-host.component.html
@@ -1,0 +1,18 @@
+@for (modal of modals(); track modal.id) {
+  <app-generic-modal
+    [title]="modal.config.title || 'Modal'"
+    [subtitle]="modal.config.subtitle"
+    [icon]="modal.config.icon"
+    [size]="modal.config.size || 'medium'"
+    [bodyTemplate]="modal.config.bodyTemplate"
+    [footerTemplate]="modal.config.footerTemplate"
+    [data]="modal.config.data ?? null"
+    [footerButtons]="modal.config.footerButtons ?? (modal.config.message ? [{ label: 'OK', variant: 'primary' }]: [])"
+    [closeOnEsc]="modal.config.closeOnEsc ?? true"
+    [closeOnBackdrop]="modal.config.closeOnBackdrop ?? true"
+    (closed)="modalService.closeDynamic(modal.id)">
+    <div modal-body *ngIf="!modal.config.bodyTemplate && modal.config.message" class="modal-message">
+      {{ modal.config.message }}
+    </div>
+  </app-generic-modal>
+}

--- a/Frontend/src/app/modals/modal-host/modal-host.component.ts
+++ b/Frontend/src/app/modals/modal-host/modal-host.component.ts
@@ -1,0 +1,16 @@
+import { Component, inject } from '@angular/core';
+import { NgIf, NgTemplateOutlet } from '@angular/common';
+import { ModalService } from '../../services/modal.service';
+import { GenericModalComponent } from '../generic-modal/generic-modal.component';
+
+@Component({
+  selector: 'app-modal-host',
+  standalone: true,
+  imports: [NgIf, NgTemplateOutlet, GenericModalComponent],
+  templateUrl: './modal-host.component.html',
+  styleUrl: './modal-host.component.css'
+})
+export class ModalHostComponent {
+  protected modalService = inject(ModalService);
+  protected modals = this.modalService.getDynamicModals();
+}

--- a/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.html
+++ b/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.html
@@ -1,4 +1,4 @@
-<app-generic-modal title="Configure your own Drink" (closed)="closeModal()">
+<app-generic-modal title="Configure your own Drink" [size]="'large'" (closed)="closeModal()">
     <div id="ingredient-list" modal-body>
       <div class="ai-generate">
       <textarea id="prompt"

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
@@ -1,4 +1,4 @@
-<app-generic-modal title="{{selectedDrink()?.name}}" (closed)="closeModal()">
+<app-generic-modal title="{{selectedDrink()?.name}}" [size]="'medium'" (closed)="closeModal()">
   <div modal-body>
     <div id="drink-overview">
       @if (selectedDrink()?.imgUrl) {

--- a/Frontend/src/app/modals/status-modal/status-modal.component.html
+++ b/Frontend/src/app/modals/status-modal/status-modal.component.html
@@ -1,4 +1,4 @@
-<app-generic-modal title="Status" (closed)="closeModal()">
+<app-generic-modal title="Status" [size]="'small'" (closed)="closeModal()">
   <div modal-body>
     <div *ngIf="progressVisible" class="progress-container">
       <div class="progress-bar" [style.width.%]="progress"></div>

--- a/Frontend/src/app/modals/user-modal/user-modal.component.html
+++ b/Frontend/src/app/modals/user-modal/user-modal.component.html
@@ -1,4 +1,4 @@
-<app-generic-modal [title]="mode() === 'login' ? 'Login' : 'Register'" (closed)="closeModal()">
+<app-generic-modal [title]="mode() === 'login' ? 'Login' : 'Register'" [size]="'medium'" (closed)="closeModal()">
   <form (ngSubmit)="onSubmit()" modal-body #authForm="ngForm">
     <ng-container *ngIf="mode() === 'login'">
       <div class="flex-row">

--- a/Frontend/src/app/services/modal.service.ts
+++ b/Frontend/src/app/services/modal.service.ts
@@ -1,4 +1,6 @@
-import {effect, computed, Injectable, signal, WritableSignal} from '@angular/core';
+import { Injectable, WritableSignal, computed, effect, signal, TemplateRef } from '@angular/core';
+import { GenericModalTemplateContext } from '../modals/generic-modal/generic-modal.component';
+
 export enum ModalType{
   CustomOrder,
   Order,
@@ -8,6 +10,37 @@ export enum ModalType{
   User,
   Account
 }
+
+export type ModalButtonVariant = 'primary' | 'secondary' | 'danger';
+
+export interface ModalButtonConfig {
+  label: string;
+  variant?: ModalButtonVariant;
+  closeOnClick?: boolean;
+  action?: () => void;
+}
+
+export interface ModalConfig<TData = unknown> {
+  id?: string;
+  title?: string;
+  subtitle?: string;
+  icon?: 'info' | 'success' | 'warning' | 'error';
+  size?: 'small' | 'medium' | 'large' | 'full' | string;
+  message?: string;
+  data?: TData | null;
+  bodyTemplate?: TemplateRef<GenericModalTemplateContext<TData>>;
+  footerTemplate?: TemplateRef<GenericModalTemplateContext<TData>>;
+  footerButtons?: ModalButtonConfig[];
+  closeOnEsc?: boolean;
+  closeOnBackdrop?: boolean;
+}
+
+interface ActiveModal<TData = unknown> {
+  id: string;
+  config: ModalConfig<TData>;
+  restoreFocus?: HTMLElement | null;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -15,12 +48,15 @@ export class ModalService {
 
   constructor() {
     effect(() => {
-      document.body.style.overflow = this.modalStack().length > 0 ? 'hidden' : '';
+      const hasModal = this.modalStack().length > 0 || this.dynamicModals().length > 0;
+      document.body.style.overflow = hasModal ? 'hidden' : '';
     });
   }
 
   private modalStack: WritableSignal<{type: ModalType; data: any; persist: boolean;}[]> = signal([]);
   private persistedData: Record<ModalType, any> = {} as Record<ModalType, any>;
+
+  private dynamicModals: WritableSignal<ActiveModal[]> = signal([]);
 
   closeModal(keepData: boolean = false) {
     const stack = [...this.modalStack()];
@@ -38,6 +74,7 @@ export class ModalService {
   closeAll() {
     this.modalStack.set([]);
     this.persistedData = {} as Record<ModalType, any>;
+    this.dynamicModals.set([]);
   }
 
   openModal(modal: ModalType, data: any = null, persist: boolean = false) {
@@ -68,5 +105,40 @@ export class ModalService {
       const stack = this.modalStack();
       return stack.length > 0 ? stack[stack.length - 1].data : null;
     });
+  }
+
+  // Template-driven modal API
+  open<TData = unknown>(config: ModalConfig<TData>) {
+    const fallbackId = `modal-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const id = config.id ?? (globalThis.crypto?.randomUUID?.() ?? fallbackId);
+    const modal: ActiveModal<TData> = {
+      id,
+      config: {
+        size: 'medium',
+        closeOnBackdrop: true,
+        closeOnEsc: true,
+        ...config,
+      },
+      restoreFocus: document.activeElement as HTMLElement | null,
+    };
+    this.dynamicModals.set([...this.dynamicModals(), modal]);
+    return {
+      id,
+      close: () => this.closeDynamic(id),
+    };
+  }
+
+  closeDynamic(id: string) {
+    const current = this.dynamicModals();
+    const modal = current.find(m => m.id === id);
+    const stack = current.filter(m => m.id !== id);
+    this.dynamicModals.set(stack);
+    if (modal?.restoreFocus && document.body.contains(modal.restoreFocus)) {
+      modal.restoreFocus.focus({ preventScroll: true });
+    }
+  }
+
+  getDynamicModals() {
+    return this.dynamicModals.asReadonly();
   }
 }


### PR DESCRIPTION
## Summary
- replace the generic modal with a reusable `<dialog>` based shell that centralizes header/body/footer styling and accessibility
- add a modal host and service API to open template-driven modals and restore focus while locking the page scroll
- migrate existing drink/user/status/account modals to the shared shell sizes and document the new architecture and migration steps

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932fc13f2cc8322acdc4cde3622c104)