### PR TITLE
Add draggable drink queue widget

### DIFF
--- a/Frontend/src/app/app.component.html
+++ b/Frontend/src/app/app.component.html
@@ -48,6 +48,7 @@
 
 <app-background-leaves>
   <router-outlet></router-outlet>
+  <app-order-queue-widget *ngIf="isAtHomeScreen()"></app-order-queue-widget>
   <app-order-custom-drink-modal id="order-custom-drink-modal" [hidden]="displayedModal() != ModalType.CustomOrder"></app-order-custom-drink-modal>
   <app-order-drink-modal id="order-drink-modal" [hidden]="displayedModal() != ModalType.Order"></app-order-drink-modal>
   <app-drink-modal id="drink-modal" [hidden]="displayedModal()!=ModalType.AddDrink && displayedModal()!=ModalType.EditDrink"></app-drink-modal>

--- a/Frontend/src/app/app.component.ts
+++ b/Frontend/src/app/app.component.ts
@@ -24,6 +24,7 @@ import {LoadingSpinnerComponent} from './loading-spinner/loading-spinner.compone
 import {BackgroundLeavesComponent} from './background-leaves/background-leaves.component';
 import {AccountModalComponent} from './modals/account-modal/account-modal.component';
 import {FpsService} from './services/fps.service';
+import {OrderQueueWidgetComponent} from './order-queue-widget/order-queue-widget.component';
 
 @Component({
   selector: 'app-root',
@@ -40,7 +41,8 @@ import {FpsService} from './services/fps.service';
     StatusModalComponent,
     LoadingSpinnerComponent,
     BackgroundLeavesComponent,
-    AccountModalComponent
+    AccountModalComponent,
+    OrderQueueWidgetComponent
   ],
   templateUrl: './app.component.html',
   standalone: true,

--- a/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.ts
+++ b/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.ts
@@ -4,6 +4,7 @@ import {DrinkIngredient, Ingredient, IngredientsService, OrderPreparation} from 
 import {ModalService} from '../../services/modal.service';
 import {ErrorHandlingComponent} from '../../services/error-handling';
 import {GenericModalComponent} from '../generic-modal/generic-modal.component';
+import {OrderQueueService} from '../../services/order-queue.service';
 
 @Component({
   selector: 'app-order-custom-drink-modal',
@@ -15,6 +16,7 @@ import {GenericModalComponent} from '../generic-modal/generic-modal.component';
 export class OrderCustomDrinkModalComponent extends ErrorHandlingComponent {
   private readonly ingredientsService = inject(IngredientsService);
   private readonly modalService = inject(ModalService);
+  private readonly orderQueueService = inject(OrderQueueService);
 
   availableIngredients: WritableSignal<Ingredient[]> = signal([]);
   orderIngredients: WritableSignal<OrderPreparation[]> = signal([]);
@@ -92,10 +94,11 @@ export class OrderCustomDrinkModalComponent extends ErrorHandlingComponent {
     this.clearFieldError();
     try {
       if (this.orderIngredients().every(ing => ing.status === '')) {
-        await this.ingredientsService.postOrder(this.orderIngredients().map(ing => ({
+        const order = await this.ingredientsService.postOrder(this.orderIngredients().map(ing => ({
           ingredientName: ing.ingredientName,
           amount: ing.amount
         })));
+        this.orderQueueService.trackOrder(order);
         this.closeModal();
       }
     } catch (e: unknown) {

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.ts
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.ts
@@ -5,6 +5,7 @@ import {Drink, DrinkService} from '../../services/drink.service';
 import {ModalService, ModalType} from '../../services/modal.service';
 import {ErrorHandlingComponent} from '../../services/error-handling';
 import {FormsModule} from '@angular/forms';
+import {OrderQueueService} from '../../services/order-queue.service';
 
 @Component({
   selector: 'app-order-drink-modal',
@@ -20,6 +21,7 @@ import {FormsModule} from '@angular/forms';
 export class OrderDrinkModalComponent extends ErrorHandlingComponent {
   private readonly drinkService = inject(DrinkService);
   private readonly modalService = inject(ModalService);
+  private readonly orderQueueService = inject(OrderQueueService);
   selectedDrink: Signal<Drink | null> = this.modalService.getModalData();
   containsIce = signal(false);
 
@@ -33,7 +35,8 @@ export class OrderDrinkModalComponent extends ErrorHandlingComponent {
     this.clearGlobalError();
     try {
       if (this.selectedDrink()) {
-        await this.drinkService.orderDrink(this.selectedDrink()!.id, this.containsIce());
+        const order = await this.drinkService.orderDrink(this.selectedDrink()!.id, this.containsIce());
+        this.orderQueueService.trackOrder(order);
         this.closeModal();
       }
     } catch (e) {

--- a/Frontend/src/app/order-queue-widget/order-queue-widget.component.css
+++ b/Frontend/src/app/order-queue-widget/order-queue-widget.component.css
@@ -1,0 +1,207 @@
+.order-queue-wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+  transition: transform 220ms ease;
+}
+
+.order-queue-wrapper.open {
+  gap: 6px;
+}
+
+.order-queue-wrapper:active {
+  cursor: grabbing;
+}
+
+.bubble {
+  position: relative;
+  width: 200px;
+  min-height: 90px;
+  background: linear-gradient(135deg, #f7f7ff 0%, #ffffff 70%);
+  border: 2px solid #d2d7ff;
+  border-radius: 50%;
+  box-shadow: 0 16px 38px rgba(89, 105, 255, 0.2), 0 4px 18px rgba(0, 0, 0, 0.08);
+  display: grid;
+  place-items: center;
+  padding: 14px 18px;
+  text-align: center;
+  color: #2d2d4a;
+  font-weight: 600;
+  animation: float 4s ease-in-out infinite;
+  transition: transform 260ms ease, box-shadow 260ms ease, border-radius 260ms ease;
+}
+
+.bubble.locked {
+  background: linear-gradient(135deg, #fff2e0 0%, #ffffff 60%);
+  border-color: #ffb36b;
+  box-shadow: 0 14px 30px rgba(255, 140, 61, 0.24), 0 4px 14px rgba(0, 0, 0, 0.08);
+}
+
+.bubble-halo {
+  position: absolute;
+  inset: 12px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(111, 132, 255, 0.2), transparent 60%);
+  filter: blur(8px);
+  z-index: -1;
+}
+
+.bubble p {
+  margin: 0;
+  line-height: 1.3;
+  font-size: 16px;
+}
+
+.order-queue-wrapper.open .bubble {
+  transform: translateY(-6px) scale(1.02);
+  border-radius: 26px;
+  box-shadow: 0 18px 32px rgba(89, 105, 255, 0.28);
+}
+
+.order-queue-wrapper.open .bubble::after {
+  content: "";
+  position: absolute;
+  bottom: -12px;
+  left: 50%;
+  width: 3px;
+  height: 18px;
+  background: linear-gradient(180deg, rgba(89, 105, 255, 0.8), rgba(131, 238, 255, 0.8));
+  transform: translateX(-50%);
+}
+
+.timeline {
+  width: 220px;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 18px;
+  border: 1px solid #d7ddff;
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.08);
+  padding: 16px 18px 14px;
+  backdrop-filter: blur(3px);
+  animation: fold-down 240ms ease;
+}
+
+.order-queue-wrapper.open .timeline {
+  margin-top: -8px;
+}
+
+.timeline-label {
+  font-weight: 700;
+  color: #2d2d4a;
+  margin-bottom: 10px;
+  letter-spacing: 0.3px;
+}
+
+.timeline-track {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 0;
+}
+
+.timeline-line {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: linear-gradient(180deg, rgba(89, 105, 255, 0.7), rgba(131, 238, 255, 0.6));
+  animation: pulse 2.4s ease-in-out infinite;
+  transform: translateX(-50%);
+}
+
+.timeline-nodes {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 10px;
+}
+
+.timeline-node {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 8px;
+  padding-left: 6px;
+}
+
+.node-circle {
+  height: 34px;
+  width: 34px;
+  display: grid;
+  place-items: center;
+  background: #f1f3ff;
+  color: #394dff;
+  border-radius: 50%;
+  border: 2px solid #c9d1ff;
+  box-shadow: 0 6px 14px rgba(89, 105, 255, 0.16);
+  font-weight: 700;
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.timeline-node.user-node .node-circle {
+  height: 44px;
+  width: 44px;
+  background: #e8f7ff;
+  border-color: #6dd5ff;
+  color: #00648d;
+  box-shadow: 0 10px 22px rgba(0, 140, 204, 0.24);
+  transform: scale(1.05);
+}
+
+.node-label {
+  font-size: 14px;
+  color: #3a3a53;
+  background: rgba(233, 237, 255, 0.6);
+  padding: 6px 10px;
+  border-radius: 12px;
+  border: 1px solid #e2e7ff;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.04);
+  transition: transform 150ms ease;
+}
+
+.timeline-node.user-node .node-label {
+  color: #005b81;
+  font-weight: 700;
+  background: rgba(217, 245, 255, 0.8);
+  border-color: #b6e9ff;
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes fold-down {
+  0% {
+    opacity: 0;
+    transform: translateY(-10px) scaleY(0.92);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scaleY(1);
+  }
+}

--- a/Frontend/src/app/order-queue-widget/order-queue-widget.component.html
+++ b/Frontend/src/app/order-queue-widget/order-queue-widget.component.html
@@ -1,0 +1,33 @@
+@if (shouldShowBubble()) {
+  <div
+    class="order-queue-wrapper"
+    [class.open]="timelineOpen()"
+    [style.transform]="'translate(' + position().x + 'px,' + position().y + 'px)'"
+    (pointerdown)="onPointerDown($event)"
+    (pointermove)="onPointerMove($event)"
+    (pointerup)="onPointerUp()"
+    (pointercancel)="onPointerUp()"
+  >
+    <div class="bubble" [class.locked]="isLocked()" (click)="toggleTimeline($event)">
+      <div class="bubble-halo"></div>
+      <p>{{ getBubbleText() }}</p>
+    </div>
+
+    @if (timelineOpen()) {
+      <div class="timeline">
+        <div class="timeline-label">Live queue</div>
+        <div class="timeline-track">
+          <div class="timeline-line"></div>
+          <div class="timeline-nodes">
+            @for (entry of timelineEntries; track trackByOrderId) {
+              <div class="timeline-node" [class.user-node]="entry.isUser">
+                <div class="node-circle">{{ entry.position }}</div>
+                <div class="node-label">{{ entry.isUser ? 'You' : entry.order.user }}</div>
+              </div>
+            }
+          </div>
+        </div>
+      </div>
+    }
+  </div>
+}

--- a/Frontend/src/app/order-queue-widget/order-queue-widget.component.ts
+++ b/Frontend/src/app/order-queue-widget/order-queue-widget.component.ts
@@ -1,0 +1,145 @@
+import {Component, effect, inject, OnDestroy, OnInit, signal} from '@angular/core';
+import {NgClass, NgForOf, NgIf} from '@angular/common';
+import {OrdersService, IncomingOrder} from '../services/orders.service';
+import {OrderQueueService} from '../services/order-queue.service';
+import {UserService} from '../services/user.service';
+
+interface TimelineEntry {
+  order: IncomingOrder;
+  position: number;
+  isUser: boolean;
+}
+
+@Component({
+  selector: 'app-order-queue-widget',
+  standalone: true,
+  imports: [NgIf, NgForOf, NgClass],
+  templateUrl: './order-queue-widget.component.html',
+  styleUrl: './order-queue-widget.component.css'
+})
+export class OrderQueueWidgetComponent implements OnInit, OnDestroy {
+  private readonly ordersService = inject(OrdersService);
+  private readonly orderQueueService = inject(OrderQueueService);
+  private readonly userService = inject(UserService);
+
+  timelineOpen = signal(false);
+  position = signal<{ x: number; y: number }>({
+    x: window.innerWidth - 180,
+    y: window.innerHeight - 220
+  });
+  isDragging = signal(false);
+  private dragStart = { x: 0, y: 0 };
+  private dragOrigin = { x: 0, y: 0 };
+  private holdTimeout?: number;
+  private hasMoved = false;
+
+  constructor() {
+    effect(() => {
+      if (this.orderQueueService.statusMessage()) {
+        this.timelineOpen.set(false);
+      }
+    });
+  }
+
+  ngOnInit(): void {
+    this.ordersService.connectWebSocket();
+  }
+
+  ngOnDestroy(): void {
+    this.ordersService.disconnectWebSocket();
+    window.clearTimeout(this.holdTimeout);
+  }
+
+  shouldShowBubble(): boolean {
+    return !!this.orderQueueService.statusMessage() || this.getTrackedPendingOrders().length > 0;
+  }
+
+  isLocked(): boolean {
+    return this.orderQueueService.messageLocked();
+  }
+
+  toggleTimeline(event?: Event) {
+    event?.stopPropagation();
+    if (this.orderQueueService.messageLocked()) return;
+    if (this.isDragging() || this.hasMoved) return;
+    this.timelineOpen.update(open => !open);
+  }
+
+  getBubbleText(): string {
+    const statusMessage = this.orderQueueService.statusMessage();
+    if (statusMessage) {
+      return statusMessage;
+    }
+    const position = this.getLowestUserPosition();
+    if (position !== null) {
+      return `Your drink is at position ${position}`;
+    }
+    return 'You have no pending drinks';
+  }
+
+  get timelineEntries(): TimelineEntry[] {
+    const pending = this.ordersService.orders();
+    const username = this.userService.username();
+    return pending.map((order, index) => ({
+      order,
+      position: index + 1,
+      isUser: order.user === username
+    }));
+  }
+
+  onPointerDown(event: PointerEvent) {
+    this.holdTimeout = window.setTimeout(() => {
+      this.isDragging.set(true);
+    }, 180);
+    this.dragStart = { x: event.clientX, y: event.clientY };
+    this.dragOrigin = { ...this.position() };
+    this.hasMoved = false;
+  }
+
+  onPointerMove(event: PointerEvent) {
+    if (!this.isDragging()) return;
+    event.preventDefault();
+    const deltaX = event.clientX - this.dragStart.x;
+    const deltaY = event.clientY - this.dragStart.y;
+    const nextX = this.dragOrigin.x + deltaX;
+    const nextY = this.dragOrigin.y + deltaY;
+    this.position.set(this.keepWithinBounds(nextX, nextY));
+    this.hasMoved = true;
+  }
+
+  onPointerUp() {
+    window.clearTimeout(this.holdTimeout);
+    if (this.isDragging()) {
+      this.isDragging.set(false);
+    }
+  }
+
+  trackByOrderId(index: number, entry: TimelineEntry) {
+    return entry.order.id ?? index;
+  }
+
+  private getTrackedPendingOrders(): IncomingOrder[] {
+    const pending = this.ordersService.orders();
+    const tracked = new Set(this.orderQueueService.trackedOrderIds());
+    const username = this.userService.username();
+    return pending.filter(order => tracked.has(order.id) && order.user === username);
+  }
+
+  private getLowestUserPosition(): number | null {
+    const pending = this.ordersService.orders();
+    const userOrders = this.getTrackedPendingOrders();
+    const positions = userOrders
+      .map(order => pending.findIndex(o => o.id === order.id) + 1)
+      .filter(pos => pos > 0);
+    return positions.length > 0 ? Math.min(...positions) : null;
+  }
+
+  private keepWithinBounds(x: number, y: number): { x: number; y: number } {
+    const margin = 20;
+    const maxX = window.innerWidth - margin;
+    const maxY = window.innerHeight - margin;
+    const boundedX = Math.min(Math.max(margin, x), maxX);
+    const boundedY = Math.min(Math.max(margin, y), maxY);
+    return { x: boundedX, y: boundedY };
+  }
+}

--- a/Frontend/src/app/services/drink.service.ts
+++ b/Frontend/src/app/services/drink.service.ts
@@ -1,9 +1,9 @@
 import {inject, Injectable, signal, WritableSignal} from '@angular/core';
-import {firstValueFrom, Observable} from 'rxjs';
-import {HttpClient, HttpErrorResponse, HttpResponse} from '@angular/common/http';
-import {ErrorService} from './error.service';
+import {firstValueFrom} from 'rxjs';
+import {HttpClient} from '@angular/common/http';
 import {UserService} from './user.service';
 import {BASE_URL} from '../app.config';
+import {IncomingOrder} from './orders.service';
 
 export interface DrinkBase {
   name: string;
@@ -46,15 +46,17 @@ export class DrinkService {
     this.drinks.update(drinks => [...drinks, this.transformDrink(drink)]);
   }
 
-  async orderDrink(ID: number, containsIce: boolean = false) {
+  async orderDrink(ID: number, containsIce: boolean = false): Promise<IncomingOrder | null> {
     const jwt = this.userService.getTokenFromStorage();
     const headers = {
       Authorization: `Bearer ${jwt}`
     };
-    await firstValueFrom(this.httpClient.post(this.apiBaseUrl + `/orders/drink/${ID}?containsIce=${containsIce}`, {}, {
+    const response = await firstValueFrom(this.httpClient.post<IncomingOrder>(this.apiBaseUrl + `/orders/drink/${ID}?containsIce=${containsIce}`, {}, {
       headers,
       observe: 'response'
     }));
+
+    return response.body ?? null;
   }
 
   async deleteDrink(ID: number) {

--- a/Frontend/src/app/services/ingredients.service.ts
+++ b/Frontend/src/app/services/ingredients.service.ts
@@ -1,10 +1,10 @@
 import {inject, Injectable, signal, WritableSignal} from '@angular/core';
-import {HttpClient, HttpHeaders} from '@angular/common/http';
+import {HttpClient} from '@angular/common/http';
 import {firstValueFrom} from 'rxjs';
-import {ErrorService} from './error.service';
 import {UserService} from './user.service';
 import {BASE_URL} from '../app.config';
 import {DrinkBase} from './drink.service';
+import {IncomingOrder} from './orders.service';
 
 export interface DrinkIngredient {
   ingredientName: string;
@@ -49,12 +49,17 @@ export class IngredientsService {
     }
   }
 
-  async postOrder(ingredients: DrinkIngredient[]) {
+  async postOrder(ingredients: DrinkIngredient[]): Promise<IncomingOrder | null> {
     const jwt = this.userService.getTokenFromStorage();
     const headers = {
       Authorization: `Bearer ${jwt}`
     };
-    await firstValueFrom(this.httpClient.post<number>(this.apiBaseUrl + "/orders/custom-drink", ingredients, {headers}));
+    const response = await firstValueFrom(this.httpClient.post<IncomingOrder>(this.apiBaseUrl + "/orders/custom-drink", ingredients, {
+      headers,
+      observe: 'response'
+    }));
+
+    return response.body ?? null;
   }
 
   async generateOrder(prompt: string): Promise<DrinkIngredient[]> {

--- a/Frontend/src/app/services/order-queue.service.ts
+++ b/Frontend/src/app/services/order-queue.service.ts
@@ -1,0 +1,126 @@
+import {effect, inject, Injectable, signal} from '@angular/core';
+import {IncomingOrder, OrdersService} from './orders.service';
+import {UserService} from './user.service';
+
+const TRACKED_KEY = 'trackedOrders';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OrderQueueService {
+  private readonly ordersService = inject(OrdersService);
+  private readonly userService = inject(UserService);
+  private readonly lastKnownStatuses = new Map<number, number>();
+  private statusTimeout?: number;
+  private hasReceivedSnapshot = false;
+
+  trackedOrderIds = signal<number[]>(this.loadTrackedIds());
+  statusMessage = signal<string | null>(null);
+  messageLocked = signal<boolean>(false);
+
+  constructor() {
+    effect(() => {
+      const username = this.userService.username();
+      if (!username) {
+        this.clearTrackedOrders();
+        this.clearStatusMessage();
+      }
+    });
+
+    effect(() => {
+      const orders = this.ordersService.allOrders();
+      this.updateTrackedStatuses(orders);
+    });
+  }
+
+  trackOrder(order: IncomingOrder | null): void {
+    if (!order) return;
+    if (order.user !== this.userService.username()) return;
+    const updated = Array.from(new Set([...this.trackedOrderIds(), order.id]));
+    this.trackedOrderIds.set(updated);
+    this.persistTrackedIds(updated);
+    this.lastKnownStatuses.set(order.id, order.status);
+  }
+
+  private updateTrackedStatuses(allOrders: IncomingOrder[]): void {
+    const tracked = this.trackedOrderIds();
+    if (tracked.length === 0) return;
+
+    if (!this.hasReceivedSnapshot) {
+      this.hasReceivedSnapshot = true;
+      if (allOrders.length === 0) return;
+    }
+
+    if (allOrders.length === 0) {
+      this.clearTrackedOrders();
+      return;
+    }
+
+    const pendingIds: number[] = [];
+    const orderMap = new Map(allOrders.map(order => [order.id, order]));
+
+    tracked.forEach(id => {
+      const order = orderMap.get(id);
+      if (!order) {
+        this.lastKnownStatuses.delete(id);
+        return;
+      }
+      const previousStatus = this.lastKnownStatuses.get(id) ?? order.status;
+      if (previousStatus === 0 && order.status !== 0) {
+        this.handleStatusChange(order.status);
+      }
+      this.lastKnownStatuses.set(id, order.status);
+      if (order.status === 0) {
+        pendingIds.push(id);
+      }
+    });
+
+    if (pendingIds.length !== tracked.length) {
+      this.trackedOrderIds.set(pendingIds);
+      this.persistTrackedIds(pendingIds);
+    }
+
+    const pendingSet = new Set(pendingIds);
+    this.lastKnownStatuses.forEach((_value, key) => {
+      if (!pendingSet.has(key)) {
+        this.lastKnownStatuses.delete(key);
+      }
+    });
+  }
+
+  private handleStatusChange(status: number): void {
+    const message = status === 1 ? 'Your drink is being mixed' : 'Your order has been canceled';
+    this.statusMessage.set(message);
+    this.messageLocked.set(true);
+    window.clearTimeout(this.statusTimeout);
+    this.statusTimeout = window.setTimeout(() => {
+      this.clearStatusMessage();
+    }, 5000);
+  }
+
+  private clearStatusMessage(): void {
+    this.statusMessage.set(null);
+    this.messageLocked.set(false);
+  }
+
+  private clearTrackedOrders(): void {
+    this.trackedOrderIds.set([]);
+    this.persistTrackedIds([]);
+    this.lastKnownStatuses.clear();
+    this.hasReceivedSnapshot = false;
+  }
+
+  private loadTrackedIds(): number[] {
+    try {
+      const raw = localStorage.getItem(TRACKED_KEY);
+      return raw ? JSON.parse(raw) : [];
+    } catch (e) {
+      console.error('Failed to load tracked orders', e);
+      return [];
+    }
+  }
+
+  private persistTrackedIds(ids: number[]): void {
+    localStorage.setItem(TRACKED_KEY, JSON.stringify(ids));
+  }
+}

--- a/Frontend/src/app/services/orders.service.ts
+++ b/Frontend/src/app/services/orders.service.ts
@@ -29,9 +29,17 @@ export class OrdersService {
   private wsUrl = inject(WS_URL);
   private readonly userService =inject(UserService);
   private ws?: WebSocket;
+  private connectionCounter = 0;
   public orders = signal<IncomingOrder[]>([]);
+  public allOrders = signal<IncomingOrder[]>([]);
 
   connectWebSocket(): void {
+    if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+      this.connectionCounter++;
+      return;
+    }
+
+    this.connectionCounter++;
     this.ws = new WebSocket(this.wsUrl);
     this.ws.onmessage = evt => {
       const all: IncomingOrder[] = JSON.parse(evt.data);
@@ -39,13 +47,26 @@ export class OrdersService {
         order.totalAmount = order.orderIngredients.reduce((sum, ingredient) => {
           return sum + (ingredient.amount || 0);
         }, 0);
-      })
-      this.orders.set(all.filter(o => o.status === 0));
+      });
+      const sortedOrders = all.sort((a, b) => new Date(a.orderDate).getTime() - new Date(b.orderDate).getTime());
+      this.allOrders.set(sortedOrders);
+      this.orders.set(sortedOrders.filter(o => o.status === 0));
+    };
+    this.ws.onclose = () => {
+      this.connectionCounter = 0;
+      this.allOrders.set([]);
+      this.orders.set([]);
     };
     this.ws.onerror = () => console.error('WS-Error OrderTerminal');
   }
   disconnectWebSocket(): void {
-    this.ws?.close();
+    if (this.connectionCounter > 0) {
+      this.connectionCounter--;
+    }
+    if (this.connectionCounter === 0) {
+      this.ws?.close();
+      this.ws = undefined;
+    }
   }
 
   async confirm(orderId: number) {


### PR DESCRIPTION
## Summary
- add a draggable order queue widget that shows the user’s lowest queue position and a live timeline of pending orders
- track order ids on creation to surface status updates like mixing or cancellations via existing order websocket
- expose all order data from the websocket for shared use and gate modal order calls with the new tracking service

## Testing
- Not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69332470f16883229f9be5d2ebc1f558)