### PR TITLE
Enhance profile management and admin controls

### DIFF
--- a/Backend/HulaSwirl.Api/Users/DeleteUser.cs
+++ b/Backend/HulaSwirl.Api/Users/DeleteUser.cs
@@ -15,14 +15,14 @@ public static class DeleteUser
         JwtService jwtService,
         ObservableUserService userService)
     {
-        if (!http.IsAdmin()) return ErrorResults.Forbidden();
+        var isSelf = http.IsSelf(jwtService, username);
+        if (!isSelf && !http.IsAdmin()) return ErrorResults.Forbidden();
         var user = await db.User.FirstOrDefaultAsync(u => u.Username.ToLower() == username.ToLower());
-        
+
         if (user == null) return ErrorResults.NotFound("User not found.");
-        if (http.IsSelf(jwtService, username)) return ErrorResults.BadRequest(new ErrorDto { Message = "Cannot delete your own account", Target = username });
         if(user.Role == "system") return ErrorResults.Forbidden("Cannot delete system user");
-        if (!http.IsSystem() && user.Role == "admin") return ErrorResults.Forbidden("Cannot delete admin user unless you are a system user");
-        
+        if (!isSelf && !http.IsSystem() && user.Role == "admin") return ErrorResults.Forbidden("Cannot delete admin user unless you are a system user");
+
         db.User.Remove(user);
         await db.SaveChangesAsync();
         await userService.BroadcastAsync(username, new UserEvent { EventType = "deleted" });

--- a/Backend/HulaSwirl.Api/Users/ResetPassword.cs
+++ b/Backend/HulaSwirl.Api/Users/ResetPassword.cs
@@ -1,0 +1,46 @@
+using System.Security.Cryptography;
+using HulaSwirl.Services.DataAccess;
+using HulaSwirl.Services.Dtos;
+using HulaSwirl.Services.UserServices;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HulaSwirl.Api.Users;
+
+public static class ResetPassword
+{
+    public static async Task<IResult> HandleReset(
+        [FromRoute] string username,
+        AppDbContext db,
+        HttpContext http,
+        JwtService jwtService)
+    {
+        var isAdmin = http.IsAdmin();
+        var isSystem = http.IsSystem();
+        if (!isAdmin) return ErrorResults.Forbidden();
+
+        var user = await db.User.FirstOrDefaultAsync(u => u.Username.ToLower() == username.ToLower());
+        if (user == null) return ErrorResults.NotFound("User not found");
+        if (user.Role == "system") return ErrorResults.Forbidden("Cannot reset system user password");
+        if (!isSystem && user.Role == "admin" && !http.IsSelf(jwtService, username))
+            return ErrorResults.Forbidden("Cannot reset another admin unless you are a system user");
+
+        var newKey = GenerateReadableSecret();
+        user.KeyHash = BCryptHasher.Hash(newKey);
+
+        db.User.Update(user);
+        await db.SaveChangesAsync();
+
+        return Results.Ok(new { newKey });
+    }
+
+    private static string GenerateReadableSecret()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(12);
+        return Convert.ToBase64String(bytes)
+            .Replace("/", "8")
+            .Replace("+", "9")
+            .Replace("=", string.Empty)
+            .Substring(0, 16);
+    }
+}

--- a/Backend/HulaSwirl.Api/Users/UserApi.cs
+++ b/Backend/HulaSwirl.Api/Users/UserApi.cs
@@ -20,7 +20,18 @@ public static class UserApi
             .WithName(nameof(DeleteUser.HandleDelete))
             .WithDescription("Delete an existing user by Id")
             .WithTags("Users")
+            .RequireAuthorization()
             .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status404NotFound);
+
+        app.MapPost($"{baseUrl}/{{username}}/reset-password", ResetPassword.HandleReset)
+            .WithName(nameof(ResetPassword.HandleReset))
+            .WithDescription("Reset user password (admin only)")
+            .WithTags("Users")
+            .RequireAuthorization()
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status404NotFound);
 
         app.MapGet(baseUrl, GetAllUsers.HandleGetAll)

--- a/Frontend/src/app/modals/account-modal/account-modal.component.css
+++ b/Frontend/src/app/modals/account-modal/account-modal.component.css
@@ -1,23 +1,228 @@
-.username {
-  width: auto;
+.account-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-.user-info h2 {
-  font-size: 1.6rem;
-  margin: 0 0 10px;
+.profile-header {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.avatar {
+  width: 62px;
+  height: 62px;
+  border-radius: 50%;
+  background: var(--sunrise-gradient);
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.25rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.user-info h3 {
+  margin: 0;
+}
+
+.user-info p {
+  margin: 2px 0;
+}
+
+.role-editor {
+  margin-left: auto;
+  min-width: 180px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.6rem;
+  border-bottom: 1px solid #e1d4c4;
+  padding-bottom: 0.4rem;
+}
+
+.tabs button {
+  background: transparent;
+  border: none;
+  padding: 0.6rem 0.9rem;
+  cursor: pointer;
+  border-radius: 10px;
+  transition: background 0.2s ease, color 0.2s ease;
+  font-weight: 600;
+  color: #6a6253;
+}
+
+.tabs button.active {
+  background: #f3e5ce;
+  color: #2e2a22;
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.tab-content {
+  background: #faf3e7;
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.04);
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.info-block {
+  background: #fffaf2;
+  border-radius: 10px;
+  padding: 0.8rem 1rem;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+}
+
+.info-block h4 {
+  margin: 0 0 6px 0;
+}
+
+.muted {
+  color: #6b6660;
+}
+
+.danger-zone {
+  margin-top: 1rem;
+  background: #fff0ed;
+  border: 1px solid #ffd1c9;
+  border-radius: 10px;
+  padding: 0.9rem 1rem;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.03);
+}
+
+.danger-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.confirm {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.confirm-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.order-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.order-card {
+  background: #fffaf2;
+  border-radius: 10px;
+  padding: 0.9rem 1rem;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+}
+
+.order-main h4 {
+  margin: 0;
+}
+
+.title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.status-pill {
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: #2e2a22;
+}
+
+.status-pill.pending {
+  background: #ffe3b3;
+  color: #9a5c00;
+}
+
+.status-pill.canceled {
+  background: #ffd2d2;
+  color: #a22929;
+}
+
+.status-pill.accepted {
+  background: #d3f3c0;
+  color: #2f7a1f;
+}
+
+.ingredients {
+  margin: 0.4rem 0 0;
+  color: #514a41;
 }
 
 .action-buttons {
   display: flex;
   justify-content: center;
   width: 100%;
-  gap: 15px;
+  gap: 12px;
 }
 
-.button {
-  background: var(--cancel-btn-bg);
+.button.ghost {
+  background: transparent;
+  color: var(--cancel-btn-bg);
+  border: 1px solid var(--cancel-btn-bg);
+  box-shadow: none;
 }
 
-.row > p {
+.button.neutral-btn {
+  background: #fef5de;
+  color: #5a4e36;
+}
+
+.status {
   margin: 0;
+}
+
+.status.success {
+  color: #2f7a1f;
+}
+
+.status.error {
+  color: #c03c3c;
+}
+
+.new-key {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.4rem;
+  background: #fff1d1;
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  font-family: monospace;
+}
+
+@media (max-width: 640px) {
+  .role-editor {
+    width: 100%;
+  }
+
+  .title-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }

--- a/Frontend/src/app/modals/account-modal/account-modal.component.html
+++ b/Frontend/src/app/modals/account-modal/account-modal.component.html
@@ -1,30 +1,99 @@
-@if(userInfo()) {
-  <app-generic-modal title="My Account" (closed)="close()">
+@if(profile()) {
+  <app-generic-modal title="Profile" (closed)="close()">
     <div modal-body class="account-content">
-      <div class="user-info">
+      <div class="profile-header">
+        <div class="avatar">{{profileInitials()}}</div>
+        <div class="user-info">
           <div class="row identity">
-            <h3>{{userInfo()!.username}}</h3>
+            <h3>{{profile()!.username}}</h3>
             <h5 class="badge {{badge()}}">
               {{badge().toUpperCase()}}
             </h5>
           </div>
-          <div class="row">
-            <b>Account created on: </b>
-            <p>{{userInfo()!.createdAt | date:'MMM d, y, HH:mm'}}</p>
+          <p class="muted">Created: {{profile()!.createdAt | date:'MMM d, y, HH:mm'}}</p>
+          <p class="muted">Last login: {{profile()!.lastLogin ? (profile()!.lastLogin | date:'MMM d, y, HH:mm') : 'Never'}}</p>
+        </div>
+        <div class="role-editor" *ngIf="canManageRoles()">
+          <label class="muted">Role</label>
+          <select class="form-input" [value]="profile()!.role" (change)="updateRole($event.target.value)">
+            <option value="admin" *ngIf="userService.role() === 'system'">Admin</option>
+            <option value="operator">Operator</option>
+            <option value="user">User</option>
+          </select>
+        </div>
+      </div>
+
+      <p class="status success" *ngIf="statusMessage()">{{statusMessage()}}</p>
+      <p class="status error" *ngIf="globalError()">{{globalError()}}</p>
+      <p class="status error" *ngIf="profileError()">{{profileError()}}</p>
+
+      <div class="tabs">
+        <button type="button" [class.active]="activeTab() === 'info'" (click)="switchTab('info')">Info</button>
+        <button type="button" [class.active]="activeTab() === 'orders'" (click)="switchTab('orders')">Order History</button>
+      </div>
+
+      <div class="tab-content" *ngIf="activeTab() === 'info'">
+        <div class="info-grid">
+          <div class="info-block">
+            <h4>Account</h4>
+            <p><b>Role:</b> {{profile()!.role | titlecase}}</p>
+            <p><b>Created:</b> {{profile()!.createdAt | date:'MMM d, y, HH:mm'}}</p>
+            <p><b>Last login:</b> {{profile()!.lastLogin ? (profile()!.lastLogin | date:'MMM d, y, HH:mm') : 'Never'}}</p>
           </div>
-          <div class="row">
-            <b>Last logged in on: </b>
-            @if(userInfo()!.lastLogin) {
-              <p>{{userInfo()!.lastLogin | date:'MMM d, y, HH:mm'}}</p>
-            } @else {
-              <p>Never</p>
-            }
+          <div class="info-block" *ngIf="canResetPassword()">
+            <h4>Admin tools</h4>
+            <p class="muted">Reset the password for this user. Share the generated key with them.</p>
+            <button class="button neutral-btn" (click)="resetPassword()" [disabled]="loadingAction()">Reset password</button>
+            <div class="new-key" *ngIf="generatedKey()">
+              <span>New key:</span>
+              <code>{{generatedKey()}}</code>
+            </div>
           </div>
+        </div>
+
+        <div class="danger-zone" *ngIf="canDelete()">
+          <div class="danger-header">
+            <div>
+              <h4>Account deletion</h4>
+              <p class="muted">Deleting this account will log the user out and remove their access.</p>
+            </div>
+            <button *ngIf="!confirmingDelete()" class="button cancel-btn ghost" (click)="startDelete()">Delete account</button>
+          </div>
+          <div class="confirm" *ngIf="confirmingDelete()">
+            <p>Confirm deletion for {{profile()!.username}}.</p>
+            <div class="confirm-actions">
+              <button class="button secondary-btn" (click)="confirmingDelete.set(false)">Keep account</button>
+              <button class="button cancel-btn" (click)="deleteProfile()" [disabled]="loadingAction()">Confirm delete</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="tab-content" *ngIf="activeTab() === 'orders'">
+        <div *ngIf="orderHistory().length > 0; else emptyOrders" class="order-list">
+          <div class="order-card" *ngFor="let order of orderHistory()">
+            <div class="order-main">
+              <div class="title-row">
+                <h4>{{order.drinkName}}</h4>
+                <span class="status-pill" [ngClass]="statusClass(order.status)">{{statusLabel(order.status)}}</span>
+              </div>
+              <p class="muted">Ordered on {{order.orderDate | date:'MMM d, y, HH:mm'}}</p>
+              <p class="muted">Contains ice: {{order.containsIce ? 'Yes' : 'No'}} · {{order.totalAmount || 0}} ml</p>
+              <p class="ingredients" *ngIf="order.orderIngredients?.length">{{formatIngredients(order.orderIngredients)}}</p>
+            </div>
+          </div>
+        </div>
+        <ng-template #emptyOrders>
+          <p class="muted">No orders yet. New orders will appear here live.</p>
+        </ng-template>
       </div>
     </div>
 
     <div modal-buttons class="action-buttons">
-      <button class="button" (click)="userService.logout()">
+      <button class="button secondary-btn" (click)="close()">
+        Close
+      </button>
+      <button class="button" *ngIf="isSelf()" (click)="logout()">
         Log Out
       </button>
     </div>
@@ -36,7 +105,7 @@
     </div>
 
     <div modal-buttons class="action-buttons">
-      <button class="button secondary-btn" (click)="userService.logout()">
+      <button class="button secondary-btn" (click)="close()">
         Close
       </button>
     </div>

--- a/Frontend/src/app/modals/account-modal/account-modal.component.ts
+++ b/Frontend/src/app/modals/account-modal/account-modal.component.ts
@@ -1,37 +1,237 @@
 // src/app/modals/account-modal/account-modal.component.ts
-import {Component, effect, inject, signal, WritableSignal} from '@angular/core';
-import {DatePipe, NgIf} from '@angular/common';
-import {Router} from '@angular/router';
+import {Component, computed, effect, inject, signal, WritableSignal} from '@angular/core';
+import {DatePipe, NgClass, NgForOf, NgIf, TitleCasePipe} from '@angular/common';
 import {ModalService} from '../../services/modal.service';
 import {AccountInfo, UserService} from '../../services/user.service';
 import {GenericModalComponent} from '../generic-modal/generic-modal.component';
+import {ErrorHandlingComponent} from '../../services/error-handling';
+import {IncomingOrder, OrderIngredient, OrdersService} from '../../services/orders.service';
+
+type ProfilePayload = AccountInfo | { profile: AccountInfo; origin?: 'self' | 'admin'; refreshUsers?: () => Promise<void> | void };
 
 @Component({
   selector: 'app-account-modal',
   standalone: true,
   imports: [
     GenericModalComponent,
-    DatePipe
+    DatePipe,
+    NgIf,
+    NgForOf,
+    NgClass,
+    TitleCasePipe
   ],
   templateUrl: './account-modal.component.html',
   styleUrl: './account-modal.component.css'
 })
-export class AccountModalComponent {
+export class AccountModalComponent extends ErrorHandlingComponent {
   protected readonly userService = inject(UserService);
   private readonly modalService = inject(ModalService);
+  private readonly ordersService = inject(OrdersService);
 
-  protected userInfo: WritableSignal<null | AccountInfo> = signal(null);
-  protected badge = signal<string>("user");
+  protected profile: WritableSignal<null | AccountInfo> = signal(null);
+  protected badge = signal<string>('user');
+  protected context = signal<'self' | 'admin'>('self');
+  protected activeTab = signal<'info' | 'orders'>('info');
+  protected confirmingDelete = signal(false);
+  protected statusMessage = signal('');
+  protected generatedKey = signal('');
+  protected loadingAction = signal(false);
+  protected fieldErrors: WritableSignal<Record<string, string>> = signal({});
+  private readonly refresher = signal<(() => Promise<void> | void) | null>(null);
+
+  protected profileError = computed(() => {
+    const user = this.profile();
+    if (!user) return '';
+    return this.fieldErrors()[user.username] ?? '';
+  });
+
+  protected isSelf = computed(() => {
+    const current = this.userService.username()?.toLowerCase() ?? '';
+    const profileUser = this.profile()?.username?.toLowerCase() ?? '';
+    return !!profileUser && profileUser === current;
+  });
+
+  protected canManageRoles = computed(() => {
+    const profile = this.profile();
+    if (!profile) return false;
+    if (this.isSelf()) return false;
+    if (this.context() !== 'admin') return false;
+    if (!this.userService.hasRole('admin')) return false;
+    if (profile.role === 'system') return false;
+    if (profile.role === 'admin' && !this.userService.hasRole('system')) return false;
+    return true;
+  });
+
+  protected canResetPassword = computed(() => {
+    const profile = this.profile();
+    if (!profile) return false;
+    if (this.context() !== 'admin') return false;
+    if (!this.userService.hasRole('admin')) return false;
+    if (profile.role === 'system') return false;
+    if (profile.role === 'admin' && !this.userService.hasRole('system')) return false;
+    return true;
+  });
+
+  protected canDelete = computed(() => {
+    const profile = this.profile();
+    if (!profile) return false;
+    if (profile.role === 'system') return false;
+    if (this.isSelf()) return true;
+    if (!this.userService.hasRole('admin')) return false;
+    if (profile.role === 'admin' && !this.userService.hasRole('system')) return false;
+    return true;
+  });
+
+  protected orderHistory = computed(() => {
+    const username = this.profile()?.username?.toLowerCase();
+    if (!username) return [] as IncomingOrder[];
+    return [...this.ordersService.allOrders().filter(order => order.user.toLowerCase() === username)]
+      .sort((a, b) => new Date(b.orderDate).getTime() - new Date(a.orderDate).getTime());
+  });
 
   constructor() {
+    super();
     effect(() => {
-      this.userInfo = this.modalService.getModalData() as WritableSignal<AccountInfo>;
-      const role = this.userService.role()
-      this.badge.set(role ? role : "user");
+      const data = this.modalService.getModalData()();
+      if (data) {
+        this.ordersService.connectWebSocket();
+        this.loadProfile(data as ProfilePayload);
+      }
     });
+  }
+
+  private loadProfile(payload: ProfilePayload) {
+    this.clearGlobalError();
+    this.clearFieldError();
+    this.statusMessage.set('');
+    this.generatedKey.set('');
+    this.confirmingDelete.set(false);
+    this.activeTab.set('info');
+
+    const hasProfileWrapper = typeof (payload as { profile?: AccountInfo }).profile !== 'undefined';
+    const info = hasProfileWrapper ? (payload as any).profile as AccountInfo : payload as AccountInfo;
+    const origin = hasProfileWrapper ? (payload as any).origin ?? 'admin' : 'self';
+    const refresh = hasProfileWrapper ? (payload as any).refreshUsers ?? null : null;
+
+    this.profile.set(info as AccountInfo);
+    this.badge.set(info.role ?? 'user');
+    this.context.set(origin === 'admin' ? 'admin' : 'self');
+    this.refresher.set(refresh);
+  }
+
+  profileInitials() {
+    const name = this.profile()?.username ?? '';
+    return name.split(' ').slice(0, 2).map(n => n[0]?.toUpperCase() ?? '').join('');
+  }
+
+  switchTab(tab: 'info' | 'orders') {
+    this.activeTab.set(tab);
+  }
+
+  async updateRole(role: string) {
+    const user = this.profile();
+    if (!user || user.role === role) return;
+    this.clearGlobalError();
+    this.clearFieldError();
+    this.loadingAction.set(true);
+    try {
+      await this.userService.updateRole(user.username, role);
+      this.profile.set({ ...user, role });
+      this.badge.set(role);
+      this.statusMessage.set('Role updated successfully.');
+      await this.triggerRefresh();
+    } catch (e) {
+      this.handleError(e);
+    } finally {
+      this.loadingAction.set(false);
+    }
+  }
+
+  async resetPassword() {
+    const user = this.profile();
+    if (!user) return;
+    this.clearGlobalError();
+    this.clearFieldError();
+    this.loadingAction.set(true);
+    try {
+      const res = await this.userService.resetPassword(user.username);
+      this.generatedKey.set(res.newKey);
+      this.statusMessage.set('A new password has been generated.');
+    } catch (e) {
+      this.handleError(e);
+    } finally {
+      this.loadingAction.set(false);
+    }
+  }
+
+  startDelete() {
+    this.confirmingDelete.set(true);
+    this.statusMessage.set('Please confirm you want to remove this account.');
+  }
+
+  async deleteProfile() {
+    const user = this.profile();
+    if (!user) return;
+    this.clearGlobalError();
+    this.clearFieldError();
+    this.loadingAction.set(true);
+    try {
+      await this.userService.deleteUser(user.username);
+      await this.triggerRefresh();
+      if (this.isSelf()) {
+        await this.userService.logout();
+      } else {
+        this.statusMessage.set('The account has been removed.');
+        this.modalService.closeModal();
+      }
+    } catch (e) {
+      this.handleError(e);
+    } finally {
+      this.loadingAction.set(false);
+    }
   }
 
   close(): void {
     this.modalService.closeModal();
+  }
+
+  async logout() {
+    await this.userService.logout();
+  }
+
+  formatIngredients(ingredients: OrderIngredient[]) {
+    return ingredients.map(i => `${i.amount || 0}ml ${i.ingredientName}`).join(' · ');
+  }
+
+  statusClass(status: IncomingOrder['status']) {
+    if (status === 1) return 'accepted';
+    if (status === 2) return 'canceled';
+    return 'pending';
+  }
+
+  statusLabel(status: IncomingOrder['status']) {
+    if (status === 1) return 'Accepted';
+    if (status === 2) return 'Canceled';
+    return 'Pending';
+  }
+
+  private async triggerRefresh() {
+    const refresh = this.refresher();
+    if (refresh) {
+      await refresh();
+    }
+  }
+
+  override setFieldError(target: string, message: string) {
+    this.fieldErrors.set({ ...this.fieldErrors(), [target]: message });
+  }
+
+  override clearFieldError(field?: string) {
+    if (field) {
+      const { [field]: _, ...rest } = this.fieldErrors();
+      this.fieldErrors.set(rest);
+    } else {
+      this.fieldErrors.set({});
+    }
   }
 }

--- a/Frontend/src/app/services/user.service.ts
+++ b/Frontend/src/app/services/user.service.ts
@@ -24,13 +24,14 @@ export interface AccountInfo {
   username: string;
   role: string;
   createdAt: Date;
-  lastLogin: Date;
+  lastLogin: Date | null;
 }
 
 export interface ManagedUser {
   username: string;
   role: string;
   createdAt: Date;
+  lastLogin: Date | null;
   status: string;
 }
 
@@ -190,5 +191,14 @@ export class UserService {
       "Authorization": `Bearer ${token}`
     };
     await firstValueFrom(this.http.delete(`${this.apiBaseUrl}/users/${username}`, {headers}));
+  }
+
+  async resetPassword(username: string) {
+    const token = this.getTokenFromStorage();
+    const headers = {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${token}`
+    };
+    return await firstValueFrom(this.http.post<{ newKey: string }>(`${this.apiBaseUrl}/users/${username}/reset-password`, null, {headers}));
   }
 }

--- a/Frontend/src/app/user-management/user-management.component.css
+++ b/Frontend/src/app/user-management/user-management.component.css
@@ -1,63 +1,67 @@
 .users {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
-.user-entry {
-  background: #f1e3cc;
-  border-radius: 5px;
-  padding: 0.5rem 1rem;
-}
-
-.user-details {
+.user-card {
   display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 1rem;
   align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  background: #f7ead8;
+  border-radius: 12px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+  flex-wrap: wrap;
 }
 
-.field-error {
-  margin-top: 0.5rem;
+.avatar {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: var(--sunrise-gradient);
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
 }
 
-.name-date {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
+.user-meta {
+  flex: 1;
+  min-width: 240px;
 }
 
-.name-date > * {
+.user-meta h3 {
   margin: 0;
 }
 
-.actions {
+.user-meta p {
+  margin: 2px 0;
+}
+
+.user-actions {
   display: flex;
   align-items: center;
   gap: 0.5rem;
 }
 
-.cancel-btn {
-  padding: 0.4rem 0.8rem;
+.status {
+  margin-top: 0.35rem;
 }
 
-@media (max-width: 520px) {
-  .user-details {
-    flex-direction: column;
+.muted {
+  color: #666;
+}
+
+@media (max-width: 640px) {
+  .user-card {
     align-items: flex-start;
   }
 
-  .actions {
+  .user-actions {
     width: 100%;
-    justify-content: space-between;
-  }
-
-  .form-input {
-    flex: 2;
-  }
-
-  .cancel-btn {
-    flex: 1;
+    justify-content: flex-end;
   }
 }

--- a/Frontend/src/app/user-management/user-management.component.html
+++ b/Frontend/src/app/user-management/user-management.component.html
@@ -1,27 +1,17 @@
 <div class="users container">
-  <div class="user-entry" *ngFor="let user of users()">
-    <div class="user-details">
-      <div class="name-date">
-        <div class="row identity">
-          <h3>{{user.username}}</h3>
-          <h5 class="badge {{user.role}}">
-            {{user.role.toUpperCase()}}
-          </h5>
-        </div>
-        <p>Created: {{user.createdAt | date:'MMM d, y, HH:mm'}}</p>
+  <div class="user-card" *ngFor="let user of users()">
+    <div class="avatar">{{initials(user.username)}}</div>
+    <div class="user-meta">
+      <div class="row identity">
+        <h3>{{user.username}}</h3>
+        <h5 class="badge {{user.role}}">{{user.role.toUpperCase()}}</h5>
       </div>
-      <div *ngIf="user.role !== 'system' && !(userService.role() === 'admin' && user.role === 'admin')" class="actions">
-        <select
-          class="form-input"
-          (change)="changeRole(user, $event)"
-          [ngModel]="user.role">
-          <option *ngIf="userService.role() === 'system'" value="admin">Admin</option>
-          <option value="operator">Operator</option>
-          <option value="user">User</option>
-        </select>
-        <button class="button cancel-btn" (click)="deleteUser(user.username)">Delete</button>
-      </div>
+      <p class="muted">Created: {{user.createdAt | date:'MMM d, y, HH:mm'}}</p>
+      <p class="muted">Last login: {{user.lastLogin ? (user.lastLogin | date:'MMM d, y, HH:mm') : 'Never'}}</p>
+      <p *ngIf="user.status" class="status error">{{user.status}}</p>
     </div>
-    <p *ngIf="user.status" class="error field-error">{{user.status}}</p>
+    <div class="user-actions">
+      <button class="button secondary-btn" (click)="openProfile(user)">View Profile</button>
+    </div>
   </div>
 </div>

--- a/Frontend/src/app/user-management/user-management.component.ts
+++ b/Frontend/src/app/user-management/user-management.component.ts
@@ -1,19 +1,20 @@
 import {Component, effect, inject, signal, WritableSignal} from '@angular/core';
 import {NgForOf, NgIf, DatePipe} from '@angular/common';
-import {FormsModule} from '@angular/forms';
-import {UserService, AccountInfo, ManagedUser} from '../services/user.service';
+import {UserService, ManagedUser} from '../services/user.service';
 import {ErrorHandlingComponent} from '../services/error-handling';
 import {ErrorService} from '../services/error.service';
+import {ModalService, ModalType} from '../services/modal.service';
 
 @Component({
   selector: 'app-user-management',
   standalone: true,
-  imports: [NgForOf, FormsModule, DatePipe, NgIf],
+  imports: [NgForOf, DatePipe, NgIf],
   templateUrl: './user-management.component.html',
   styleUrl: './user-management.component.css'
 })
 export class UserManagementComponent extends ErrorHandlingComponent {
   protected readonly userService = inject(UserService);
+  private readonly modalService = inject(ModalService);
   private readonly statusService = inject(ErrorService);
   protected users: WritableSignal<ManagedUser[]> = signal([]);
 
@@ -25,27 +26,23 @@ export class UserManagementComponent extends ErrorHandlingComponent {
   }
 
   async loadUsers() {
-    this.users.set(await this.userService.getAllUsers());
-  }
-
-  async changeRole(user: ManagedUser, ev: Event) {
-    const target = ev.target as HTMLSelectElement;
     try {
-      await this.userService.updateRole(user.username, target.value);
-      await this.loadUsers();
+      this.users.set(await this.userService.getAllUsers());
     } catch (e) {
-      target.value = user.role
       this.handleError(e);
     }
   }
 
-  async deleteUser(username: string) {
-    try {
-      await this.userService.deleteUser(username);
-      this.users.update(u => u.filter(us => us.username !== username));
-    } catch (e) {
-      this.handleError(e);
-    }
+  openProfile(user: ManagedUser) {
+    this.modalService.openModal(ModalType.Account, {
+      profile: user,
+      origin: 'admin',
+      refreshUsers: () => this.loadUsers()
+    });
+  }
+
+  initials(username: string) {
+    return username.split(" ").slice(0, 2).map(n => n[0]?.toUpperCase() ?? '').join('');
   }
 
   override setFieldError(target: string, message: string) {


### PR DESCRIPTION
## Summary
- allow authenticated users to delete their own accounts and add an admin-only password reset endpoint
- redesign the account modal with info and order history tabs, confirmation for deletion, and admin role/password controls
- overhaul the user management view to show profile cards with a "View Profile" flow that reuses the modal

## Testing
- Not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936fb02c8c0832295aab46279c4f20f)