### PR TITLE
Improve modal sizing, accessibility and layouts

### DIFF
--- a/Frontend/src/app/modals/drink-modal/drink-modal.component.css
+++ b/Frontend/src/app/modals/drink-modal/drink-modal.component.css
@@ -39,10 +39,10 @@
 
 .order-ingredient {
   margin: 5px 0;
-  padding: 5px 15px;
-  border-radius: 5px;
+  padding: 10px 14px;
+  border-radius: 10px;
   background-color: #fdfded;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.11);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08);
 }
 
 .order-ingredient-details {
@@ -93,7 +93,11 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  padding: 0 10px 0 0;
+  gap: 20px;
+}
+
+.drink-modal-body {
+  align-items: flex-start;
 }
 
 #left-column{
@@ -101,7 +105,7 @@
   width: 48%;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 16px;
 }
 
 #right-column{
@@ -109,7 +113,7 @@
   width: 48%;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 16px;
 }
 
 .modal-body {
@@ -119,16 +123,43 @@
 
 h2 {
   color: #575757;
-  font-size: 20px;
+  font-size: 1.1rem;
   text-align: start;
   font-family: AdlamDisplay, serif;
   margin:0;
   font-weight: lighter;
 }
 
+#toppings-header {
+  margin-bottom: 6px;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.section-subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--primary-font-color);
+}
+
+.field-label {
+  display: block;
+  font-size: 0.9rem;
+  margin-bottom: 6px;
+  color: var(--primary-font-color);
+}
+
+#drink-title {
+  margin-bottom: 4px;
+}
+
 #drink-title{
   color: #575757;
-  font-size: 20px;
+  font-size: 1rem;
   text-align: start;
   font-family: AdlamDisplay, serif;
   margin:0;
@@ -206,7 +237,8 @@ h2 {
   box-shadow: 0 0 7px rgba(0, 0, 0, 0.18);
   overflow: hidden;
   height: 250px;
-  width: 250px;
+  width: 100%;
+  max-width: 320px;
   align-self: center;
 }
 .upload-box .preview-image {
@@ -228,20 +260,28 @@ h2 {
   background-color: #fdfded;
   padding: 5px 10px;
   border-radius: 5px;
-  font-size: 18px;
+  font-size: 1rem;
   font-weight: bold;
   box-shadow: 0 0 7px rgba(0, 0, 0, 0.24);
-  height: 30px;
-  min-height: 30px;
+  height: 40px;
+  min-height: 40px;
   box-sizing: border-box;
   max-width: 100%;
   width: 100%;
   resize: vertical;
 }
 
-#toppings-header{
-  margin-bottom: 5px;
-  margin-top:7px;
+.modal-panel {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.panel-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .order-ingredient-amount{

--- a/Frontend/src/app/modals/drink-modal/drink-modal.component.html
+++ b/Frontend/src/app/modals/drink-modal/drink-modal.component.html
@@ -1,6 +1,6 @@
-<app-generic-modal [title]="mode() === 'add' ? 'Add Drink' : 'Edit Drink'" (closed)="closeModal()">
-  <div modal-body>
-    <div id="left-column">
+<app-generic-modal [title]="mode() === 'add' ? 'Add Drink' : 'Edit Drink'" size="large" (closed)="closeModal()">
+  <div modal-body class="drink-modal-body">
+    <div id="left-column" class="modal-panel">
       <div class="upload-box" [class.drag-over]="isDragging" (click)="fileInput.click()" (dragover)="onDragOver($event)" (dragleave)="onDragLeave()" (drop)="onDrop($event)">
         @if (!imageBase64) {
           <span>Upload image</span>
@@ -10,18 +10,22 @@
         }
       </div>
       <input #fileInput type="file" accept="image/*" style="display: none" (change)="onFileSelected($event)"/>
-      <div>
-        <h2 id="toppings-header">Toppings:</h2>
-        <textarea id="drink-toppings" placeholder="No toppings" [(ngModel)]="drinkToppings"></textarea>
+      <div class="panel-section">
+        <h2 id="toppings-header">Toppings</h2>
+        <textarea id="drink-toppings" placeholder="Add toppings or garnishes..." [(ngModel)]="drinkToppings"></textarea>
       </div>
     </div>
-    <div id="right-column">
-      <div class="form-property">
+    <div id="right-column" class="modal-panel">
+      <div class="form-property panel-section">
+        <label class="field-label" for="drink-title">Drink name</label>
         <input id="drink-title" placeholder="Title" [(ngModel)]="drinkTitle" (input)="clearFieldError('name')">
         <p class="error field-error">{{drinkTitleError()}}</p>
       </div>
-      <div class="form-property">
-        <h2>Ingredients:</h2>
+      <div class="form-property panel-section">
+        <div class="section-header">
+          <h2>Ingredients</h2>
+          <p class="section-subtitle">Add ingredients and adjust amounts.</p>
+        </div>
         <p class="error field-error">{{drinkIngredientsError()}}</p>
         <div id="drink-ingredients">
           @for(ingredient of drinkIngredients(); track $index){
@@ -71,7 +75,7 @@
   </div>
   <div modal-buttons class="action-buttons">
     @if(mode() === 'edit'){
-      <button class="button cancel-btn" (click)="deleteDrink()">Delete</button>
+      <button class="button cancel-btn" type="button" (click)="deleteDrink()">Delete</button>
       <div class="checkbox-container button" (click)="drinkAvailable.set(!drinkAvailable())">
         <input type="checkbox" [(ngModel)]="drinkAvailable">
         <label>
@@ -79,6 +83,6 @@
         </label>
       </div>
     }
-    <button class="button submit-btn" (click)="submitDrink()">{{ mode() === 'add' ? 'Add' : 'Update' }}</button>
+    <button class="button submit-btn" type="button" (click)="submitDrink()">{{ mode() === 'add' ? 'Add' : 'Update' }}</button>
   </div>
 </app-generic-modal>

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.css
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.css
@@ -11,15 +11,35 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: 24px;
 }
 
 .modal-form {
   background-color: var(--popup-bg);
-  border-radius: 10px;
-  padding: 20px;
-  max-width: 550px;
-  width: 80%;
-  box-shadow: 0 0 10px 3px rgb(64, 64, 64);
+  border-radius: 16px;
+  padding: 24px;
+  width: min(92vw, 640px);
+  max-height: min(85vh, 840px);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.modal-form.modal-size-small {
+  width: min(90vw, 420px);
+  max-height: min(70vh, 460px);
+}
+
+.modal-form.modal-size-medium {
+  width: min(92vw, 640px);
+  max-height: min(80vh, 720px);
+}
+
+.modal-form.modal-size-large {
+  width: min(95vw, 980px);
+  max-height: min(88vh, 900px);
 }
 
 .modal-head {
@@ -27,21 +47,28 @@
   justify-content: space-between;
   gap: 20px;
   color: var(--primary-font-color);
+  align-items: center;
 }
 
 .modal-head h1 {
   margin: 0;
+  font-size: clamp(1.4rem, 2vw, 2rem);
+  font-weight: 600;
 }
 
 .close-modal-button {
-  font-size: 24px;
+  font-size: 1.1rem;
   font-weight: bold;
-  height: 20px;
-  width: 20px;
+  height: 36px;
+  width: 36px;
   text-align: center;
   line-height: 24px;
-  transition: 0.3s transform ease;
-  margin: -7px -7px 0 0;
+  transition: 0.3s transform ease, background-color 0.3s ease;
+  margin: -4px -4px 0 0;
+  border: none;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--primary-font-color);
 }
 .close-modal-button:after{
   content: '✖';
@@ -49,12 +76,19 @@
 .close-modal-button:hover {
   cursor: pointer;
   transform: rotate(10deg);
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.close-modal-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 2px;
 }
 
 .modal-body {
-  margin: 15px 0;
-  max-height: 310px;
+  margin: 0;
+  max-height: 55vh;
   overflow-y: auto;
+  padding-right: 4px;
 }
 
 .modal-footer {
@@ -66,13 +100,13 @@
 
 @media screen and (max-width: 650px) {
   .modal-body {
-    max-height: 400px;
+    max-height: 60vh;
   }
 }
 
 @media (max-width: 350px) {
   .modal-form {
-    width: 85%;
-    padding: 15px;
+    width: 92%;
+    padding: 16px;
   }
 }

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.html
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.html
@@ -1,8 +1,17 @@
 <div class="modal-frame">
-  <div class="modal-form">
+  <div
+    class="modal-form"
+    role="dialog"
+    aria-modal="true"
+    [attr.aria-label]="title()"
+    [class.modal-size-small]="isSmall()"
+    [class.modal-size-medium]="isMedium()"
+    [class.modal-size-large]="isLarge()"
+  >
     <div class="modal-head">
-      <h1>{{ title }}</h1>
-      <span class="close-modal-button" (click)="close()"></span>
+      <h1>{{ title() }}</h1>
+      <button class="close-modal-button" type="button" (click)="close()" aria-label="Close modal">
+      </button>
     </div>
     <div class="modal-body">
       <ng-content select="[modal-body]"></ng-content>
@@ -12,8 +21,8 @@
     </div>
     <div class="modal-buttons">
       <ng-content select="[modal-buttons]"></ng-content>
-      @for (btn of buttons; track btn) {
-        <button class="button" (click)="btn.action()">{{ btn.label }}</button>
+      @for (btn of buttons(); track btn) {
+        <button class="button" type="button" (click)="btn.action()">{{ btn.label }}</button>
       }
     </div>
   </div>

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.ts
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, output } from '@angular/core';
 
 import { ModalService } from '../../services/modal.service';
 
@@ -7,20 +7,24 @@ export interface GenericModalButton {
   action: () => void;
 }
 
+export type GenericModalSize = 'small' | 'medium' | 'large';
+
 @Component({
   selector: 'app-generic-modal',
-  standalone: true,
-  imports: [],
   templateUrl: './generic-modal.component.html',
-  styleUrls: ['./generic-modal.component.css']
+  styleUrls: ['./generic-modal.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class GenericModalComponent {
-  @Input() title: string = '';
-  //@Input() imageUrl: string | null = null;
-  @Input() buttons: GenericModalButton[] = [];
-  @Output() closed = new EventEmitter<void>();
+  readonly title = input('');
+  readonly buttons = input<GenericModalButton[]>([]);
+  readonly size = input<GenericModalSize>('medium');
+  readonly closed = output<void>();
 
-  constructor(private modalService: ModalService) {}
+  private readonly modalService = inject(ModalService);
+  protected readonly isSmall = computed(() => this.size() === 'small');
+  protected readonly isMedium = computed(() => this.size() === 'medium');
+  protected readonly isLarge = computed(() => this.size() === 'large');
 
   close() {
     this.closed.emit();

--- a/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.css
+++ b/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.css
@@ -1,8 +1,11 @@
 
 #ingredient-list {
-  max-height: 220px;
+  max-height: 380px;
   overflow-y: auto;
   overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 #ingredient-list .order-ingredient {
@@ -114,6 +117,24 @@
   border-radius: 5px;
   background-color: var(--ingredient-bg-color);
   color: var(--primary-font-color);
+  align-items: center;
+}
+
+.ai-copy {
+  min-width: 160px;
+}
+
+.ai-copy h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.ai-copy p {
+  margin: 4px 0 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: var(--heavy-font-color);
 }
 
 .ai-generate textarea {
@@ -171,6 +192,11 @@
 @media (max-width: 600px) {
   .ai-generate {
     flex-direction: column;
+    align-items: stretch;
+  }
+  .ai-copy {
+    min-width: auto;
+    text-align: center;
   }
   .ai-generate button {
     justify-content: center;

--- a/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.html
+++ b/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.html
@@ -1,10 +1,14 @@
-<app-generic-modal title="Configure your own Drink" (closed)="closeModal()">
+<app-generic-modal title="Configure your own Drink" size="large" (closed)="closeModal()">
     <div id="ingredient-list" modal-body>
       <div class="ai-generate">
-      <textarea id="prompt"
-                [(ngModel)]="prompt"
-                rows="3"
-                placeholder="Describe your perfect drink..."></textarea>
+        <div class="ai-copy">
+          <h3>AI suggestions</h3>
+          <p>Describe the taste, vibe, or ingredients you want.</p>
+        </div>
+        <textarea id="prompt"
+                  [(ngModel)]="prompt"
+                  rows="3"
+                  placeholder="Describe your perfect drink..."></textarea>
 
         <button type="button"
                 (click)="aiGenerate()"

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.css
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.css
@@ -1,13 +1,21 @@
 #drink-overview {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(200px, 260px) 1fr;
   gap: 20px;
-  margin-bottom: 10px;
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.order-modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 @media screen and (max-width: 650px) {
   #drink-overview {
-    flex-direction: column;
-    max-height: 100%;
+    grid-template-columns: 1fr;
   }
   .modal-image {
     align-self: center;
@@ -24,30 +32,35 @@ h1 {
 }
 
 h3 {
-  font-size: 1.5rem;
+  font-size: 1.3rem;
+  font-weight: 600;
 }
 
 h4 {
-  font-size: 1.2rem;
+  font-size: 1.1rem;
+  font-weight: 600;
 }
 
 p:not(.error) {
-  margin-top: 5px;
-  font-size: 1.1rem;
-  max-width: 400px;
+  margin-top: 6px;
+  font-size: 1rem;
+  max-width: 480px;
   overflow-wrap: break-word;
+  line-height: 1.6;
 }
 
 .modal-image {
-  width: 250px;
-  height: 250px;
+  width: 100%;
+  max-width: 240px;
+  height: 240px;
   box-sizing: border-box;
   overflow: hidden;
-  border-radius: 10px;
+  border-radius: 14px;
   background-color: var(--body-bg);
   display: flex;
   justify-content: center;
   align-items: center;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.15);
 }
 
 .modal-image img {
@@ -57,11 +70,11 @@ p:not(.error) {
 }
 
 #modal-ingredient-list {
-  max-height: 265px;
   min-width: 180px;
   flex: 1;
   display: flex;
   flex-direction: column;
+  gap: 12px;
 }
 
 .checkbox-container label {
@@ -72,12 +85,14 @@ ul {
   margin: 10px 0;
   padding: 0;
   list-style-type: none;
-  font-size: 1.2rem;
+  font-size: 1.05rem;
   overflow-y: auto;
+  display: grid;
+  gap: 8px;
 }
 
 ul li {
-  margin: 5px 0;
+  margin: 0;
 }
 
 ul li::before {
@@ -108,7 +123,14 @@ ul li:nth-child(6n+6)::before {
   content: "🦩";
 }
 
-[modal-buttons] {
+.detail-card {
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.order-actions {
   display: flex;
   justify-content: end;
 }

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
@@ -1,5 +1,5 @@
-<app-generic-modal title="{{selectedDrink()?.name}}" (closed)="closeModal()">
-  <div modal-body>
+<app-generic-modal [title]="selectedDrink()?.name ?? 'Drink'" size="medium" (closed)="closeModal()">
+  <div modal-body class="order-modal-body">
     <div id="drink-overview">
       @if (selectedDrink()?.imgUrl) {
         <div class="modal-image">
@@ -7,7 +7,7 @@
         </div>
       }
       <div id="modal-ingredient-list">
-        <h3>Ingredients:</h3>
+        <h3>Ingredients</h3>
         <ul>
           @for (drink of selectedDrink()?.drinkIngredients; track drink) {
             <li>{{drink.amount}}ml {{drink.ingredientName}}</li>
@@ -20,8 +20,8 @@
       </div>
     </div>
     @if(selectedDrink()?.toppings) {
-      <div id="toppings">
-        <h4>Toppings:</h4>
+      <div id="toppings" class="detail-card">
+        <h4>Toppings</h4>
         <p>{{selectedDrink()!.toppings}}</p>
       </div>
     }
@@ -29,7 +29,7 @@
   <div modal-footer>
     <p class="error global-error">{{ globalError() }}</p>
   </div>
-  <div modal-buttons>
-    <button class="button submit-btn" (click)="submitOrder()">Order</button>
+  <div modal-buttons class="order-actions">
+    <button class="button submit-btn" type="button" (click)="submitOrder()">Order</button>
   </div>
 </app-generic-modal>

--- a/Frontend/src/app/modals/status-modal/status-modal.component.css
+++ b/Frontend/src/app/modals/status-modal/status-modal.component.css
@@ -1,27 +1,45 @@
-.modal {
-  background: white;
-  padding: 1.5rem;
-  border-radius: 8px;
-  max-width: 400px;
-  margin: auto;
-  box-shadow: 0 0 10px rgba(0,0,0,0.3);
+.status-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   text-align: center;
+  gap: 12px;
+  padding: 8px 0;
 }
-button {
-  margin-top: 1rem;
-  padding: 0.5rem 1rem;
+
+.status-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  font-size: 1.8rem;
+  background: rgba(255, 255, 255, 0.15);
+  color: var(--primary-font-color);
 }
+
 #statusMessage {
-  font-size: 1.7rem;
+  font-size: 1.2rem;
+  line-height: 1.6;
   white-space: pre-line;
+  color: var(--heavy-font-color);
+}
+
+.status-actions {
+  display: flex;
+  justify-content: center;
+}
+
+.status-actions .button {
+  min-width: 140px;
 }
 .progress-container {
   width: 100%;
-  height: 20px;
-  background-color: #ddd;
-  border-radius: 10px;
+  height: 12px;
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
   overflow: hidden;
-  margin-top: 10px;
+  margin-top: 6px;
 }
 
 .progress-bar {

--- a/Frontend/src/app/modals/status-modal/status-modal.component.html
+++ b/Frontend/src/app/modals/status-modal/status-modal.component.html
@@ -1,13 +1,14 @@
-<app-generic-modal title="Status" (closed)="closeModal()">
-  <div modal-body>
+<app-generic-modal title="Status" size="small" (closed)="closeModal()">
+  <div modal-body class="status-content">
+    <div class="status-icon" aria-hidden="true">✅</div>
+    <p id="statusMessage">{{statusMessage()}}</p>
     @if (progressVisible) {
-      <div class="progress-container">
+      <div class="progress-container" aria-hidden="true">
         <div class="progress-bar" [style.width.%]="progress"></div>
       </div>
     }
-    <p id="statusMessage">{{statusMessage()}}</p>
   </div>
-  <div modal-buttons>
-    <div class="button submit-btn" (click)="closeModal()">OK</div>
+  <div modal-buttons class="status-actions">
+    <button class="button submit-btn" type="button" (click)="closeModal()">OK</button>
   </div>
 </app-generic-modal>


### PR DESCRIPTION
### Motivation
- Modals currently use a single generic size and have cramped/uneven content layouts, so they need size variants and layout improvements to match content complexity and improve UX.
- Make the modal shell more accessible and responsive so small status dialogs, medium order dialogs, and large add/edit forms feel appropriate on all viewports.

### Description
- Introduce a `size` input (`'small' | 'medium' | 'large'`) for `app-generic-modal`, migrate to `input()`/`output()` usage, add `ChangeDetectionStrategy.OnPush`, ARIA attributes, and computed size flags for template bindings in `generic-modal.component.*`.
- Add CSS variants and responsive rules for small/medium/large modals, improve spacing, focus styles, and a better close button in `generic-modal.component.css` and HTML.
- Refresh specific modal content and layouts: make `status` modal small with icon and streamlined progress UI, make `order-drink` modal medium with a two-column/grid ingredient view and detail card, make `drink` add/edit modal large with two-panel layout, padded panels and improved form grouping, and expand the `order-custom-drink` modal with improved AI suggestion copy and spacing.
- Update related templates and styles to use clearer headings, better typography, action button types, and accessible attributes to improve visual hierarchy and keyboard/focus behavior.

### Testing
- Built and served the frontend with `npm run start` (runs `ng serve`) and the application bundle generation completed successfully; the dev server stayed in watch mode.
- Automated browser check: a Playwright script was used to open the app and capture a screenshot of the add/edit drink modal and the artifact `artifacts/modal-add-drink.png` was produced (final run succeeded after revealing the modal via a short DOM evaluation).
- Unit tests (`npm test`) were not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967d285a1448322a02e9342fab34ee6)