### PR TITLE
Add modal size variants and improve modal layouts/styles

### DIFF
--- a/Frontend/src/app/modals/drink-modal/drink-modal.component.css
+++ b/Frontend/src/app/modals/drink-modal/drink-modal.component.css
@@ -29,6 +29,27 @@
   margin-top: 5px;
 }
 
+.drink-modal-body {
+  display: flex;
+  gap: 20px;
+}
+
+.drink-modal-column {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section-card {
+  background: color-mix(in srgb, var(--popup-bg), #ffffff 12%);
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .checkbox-container {
   padding: 9px 16px;
 }
@@ -93,7 +114,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  padding: 0 10px 0 0;
+  padding: 0;
 }
 
 #left-column{
@@ -142,6 +163,10 @@ h2 {
   width: 97%;
   height:30px;
   resize: vertical;
+}
+
+#drink-title::placeholder {
+  color: color-mix(in srgb, #575757, #ffffff 45%);
 }
 
 #drink-title:focus {
@@ -206,7 +231,8 @@ h2 {
   box-shadow: 0 0 7px rgba(0, 0, 0, 0.18);
   overflow: hidden;
   height: 250px;
-  width: 250px;
+  width: 100%;
+  max-width: 320px;
   align-self: center;
 }
 .upload-box .preview-image {
@@ -217,22 +243,20 @@ h2 {
   border-radius: 9px;  /* beibehaltung der runden Ecken, falls gewünscht */
 }
 
-
 .upload-box.drag-over {
   background-color: #f5f5f5;
 }
 
 #drink-toppings{
-  border: none;
+  border: 1px solid rgba(0, 0, 0, 0.1);
   outline: none;
   background-color: #fdfded;
-  padding: 5px 10px;
-  border-radius: 5px;
-  font-size: 18px;
-  font-weight: bold;
-  box-shadow: 0 0 7px rgba(0, 0, 0, 0.24);
-  height: 30px;
-  min-height: 30px;
+  padding: 10px;
+  border-radius: 10px;
+  font-size: 16px;
+  font-weight: 500;
+  box-shadow: 0 0 7px rgba(0, 0, 0, 0.16);
+  min-height: 90px;
   box-sizing: border-box;
   max-width: 100%;
   width: 100%;

--- a/Frontend/src/app/modals/drink-modal/drink-modal.component.html
+++ b/Frontend/src/app/modals/drink-modal/drink-modal.component.html
@@ -1,64 +1,70 @@
-<app-generic-modal [title]="mode() === 'add' ? 'Add Drink' : 'Edit Drink'" (closed)="closeModal()">
-  <div modal-body>
-    <div id="left-column">
-      <div class="upload-box" [class.drag-over]="isDragging" (click)="fileInput.click()" (dragover)="onDragOver($event)" (dragleave)="onDragLeave()" (drop)="onDrop($event)">
-        @if (!imageBase64) {
-          <span>Upload image</span>
-        }
-        @if (imageBase64) {
-          <img [src]="imageBase64" alt="Drink image" class="preview-image"/>
-        }
+<app-generic-modal [title]="mode() === 'add' ? 'Add Drink' : 'Edit Drink'" size="large" (closed)="closeModal()">
+  <div modal-body class="drink-modal-body">
+    <div id="left-column" class="drink-modal-column">
+      <div class="section-card">
+        <h2>Drink Image</h2>
+        <div class="upload-box" [class.drag-over]="isDragging" (click)="fileInput.click()" (dragover)="onDragOver($event)" (dragleave)="onDragLeave()" (drop)="onDrop($event)">
+          @if (!imageBase64) {
+            <span>Upload image</span>
+          }
+          @if (imageBase64) {
+            <img [src]="imageBase64" alt="Drink image" class="preview-image"/>
+          }
+        </div>
+        <input #fileInput type="file" accept="image/*" style="display: none" (change)="onFileSelected($event)"/>
       </div>
-      <input #fileInput type="file" accept="image/*" style="display: none" (change)="onFileSelected($event)"/>
-      <div>
-        <h2 id="toppings-header">Toppings:</h2>
+      <div class="section-card">
+        <h2 id="toppings-header">Toppings</h2>
         <textarea id="drink-toppings" placeholder="No toppings" [(ngModel)]="drinkToppings"></textarea>
       </div>
     </div>
-    <div id="right-column">
-      <div class="form-property">
-        <input id="drink-title" placeholder="Title" [(ngModel)]="drinkTitle" (input)="clearFieldError('name')">
-        <p class="error field-error">{{drinkTitleError()}}</p>
-      </div>
-      <div class="form-property">
-        <h2>Ingredients:</h2>
-        <p class="error field-error">{{drinkIngredientsError()}}</p>
-        <div id="drink-ingredients">
-          @for(ingredient of drinkIngredients(); track $index){
-            <div class="order-ingredient">
-              <div class="order-ingredient-details">
-                <div class="ingredient-properties">
-                  @if(ingredient.type=='new'){
-                    <input class="order-new-ingredient-name" [(ngModel)]="ingredient.ingredientName">
-                  } @else {
-                    <span class="order-new-ingredient">{{ ingredient.ingredientName }}</span>
-                  }
-                  <input min="1" max="100" type="number" class="order-ingredient-amount form-input" [(ngModel)]="ingredient.amount" (input)="clearFieldError(ingredient.ingredientName)">
-                  <span class="order-ingredient-unit">ml</span>
+    <div id="right-column" class="drink-modal-column">
+      <div class="section-card">
+        <div class="form-property">
+          <h2>Drink Details</h2>
+          <input id="drink-title" placeholder="Title" [(ngModel)]="drinkTitle" (input)="clearFieldError('name')">
+          <p class="error field-error">{{drinkTitleError()}}</p>
+        </div>
+        <div class="form-property">
+          <h2>Ingredients</h2>
+          <p class="error field-error">{{drinkIngredientsError()}}</p>
+          <div id="drink-ingredients">
+            @for(ingredient of drinkIngredients(); track $index){
+              <div class="order-ingredient">
+                <div class="order-ingredient-details">
+                  <div class="ingredient-properties">
+                    @if(ingredient.type=='new'){
+                      <input class="order-new-ingredient-name" [(ngModel)]="ingredient.ingredientName">
+                    } @else {
+                      <span class="order-new-ingredient">{{ ingredient.ingredientName }}</span>
+                    }
+                    <input min="1" max="100" type="number" class="order-ingredient-amount form-input" [(ngModel)]="ingredient.amount" (input)="clearFieldError(ingredient.ingredientName)">
+                    <span class="order-ingredient-unit">ml</span>
+                  </div>
+                  <span class="order-ingredient-delete" (click)="deleteIngredient($index)">❌</span>
                 </div>
-                <span class="order-ingredient-delete" (click)="deleteIngredient($index)">❌</span>
+                <p class="error field-error">{{ingredient.status}}</p>
               </div>
-              <p class="error field-error">{{ingredient.status}}</p>
-            </div>
-            } @empty {
-            <div class="order-ingredient">
-              <div class="order-ingredient-details">
-                <div class="ingredient-properties">
-                  <span class="order-ingredient-name">No ingredients added</span>
+              } @empty {
+              <div class="order-ingredient">
+                <div class="order-ingredient-details">
+                  <div class="ingredient-properties">
+                    <span class="order-ingredient-name">No ingredients added</span>
+                  </div>
                 </div>
               </div>
+            }
+            <div id="add-new-ingredient">
+              <select id="order-ingredient-select" class="form-input" [(ngModel)]="selectedIngredient">
+                <option value="newIngredient">New Ingredient</option>
+                @for(ingredient of availableIngredients(); track $index){
+                  <option value="{{ ingredient.ingredientName }}">{{ ingredient.ingredientName }}</option>
+                }
+              </select>
+              <input type="number" class="order-ingredient-amount form-input" [(ngModel)]="selectedAmount" min="1" step="1" max="500">
+              <span id="order-ingredient-unit">ml</span>
+              <span id="order-ingredient-add" class="button" (click)="addIngredient()">+</span>
             </div>
-          }
-          <div id="add-new-ingredient">
-            <select id="order-ingredient-select" class="form-input" [(ngModel)]="selectedIngredient">
-              <option value="newIngredient">New Ingredient</option>
-              @for(ingredient of availableIngredients(); track $index){
-                <option value="{{ ingredient.ingredientName }}">{{ ingredient.ingredientName }}</option>
-              }
-            </select>
-            <input type="number" class="order-ingredient-amount form-input" [(ngModel)]="selectedAmount" min="1" step="1" max="500">
-            <span id="order-ingredient-unit">ml</span>
-            <span id="order-ingredient-add" class="button" (click)="addIngredient()">+</span>
           </div>
         </div>
       </div>

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.css
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.css
@@ -11,15 +11,34 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: 24px;
 }
 
 .modal-form {
   background-color: var(--popup-bg);
   border-radius: 10px;
-  padding: 20px;
-  max-width: 550px;
-  width: 80%;
+  padding: 24px;
+  max-width: min(92vw, 560px);
+  width: min(92vw, 560px);
   box-shadow: 0 0 10px 3px rgb(64, 64, 64);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.modal-form--small {
+  max-width: min(90vw, 380px);
+  width: min(90vw, 380px);
+}
+
+.modal-form--medium {
+  max-width: min(92vw, 560px);
+  width: min(92vw, 560px);
+}
+
+.modal-form--large {
+  max-width: min(94vw, 920px);
+  width: min(94vw, 920px);
 }
 
 .modal-head {
@@ -27,21 +46,27 @@
   justify-content: space-between;
   gap: 20px;
   color: var(--primary-font-color);
+  align-items: center;
 }
 
 .modal-head h1 {
   margin: 0;
+  font-size: 1.6rem;
 }
 
 .close-modal-button {
-  font-size: 24px;
+  font-size: 1.2rem;
   font-weight: bold;
-  height: 20px;
-  width: 20px;
-  text-align: center;
-  line-height: 24px;
-  transition: 0.3s transform ease;
-  margin: -7px -7px 0 0;
+  height: 32px;
+  width: 32px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.1);
+  color: var(--primary-font-color);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: 0.2s transform ease, 0.2s background-color ease;
 }
 .close-modal-button:after{
   content: '✖';
@@ -49,11 +74,17 @@
 .close-modal-button:hover {
   cursor: pointer;
   transform: rotate(10deg);
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.close-modal-button:focus-visible {
+  outline: 2px solid var(--primary-font-color);
+  outline-offset: 2px;
 }
 
 .modal-body {
-  margin: 15px 0;
-  max-height: 310px;
+  margin: 0;
+  max-height: min(70vh, 520px);
   overflow-y: auto;
 }
 
@@ -64,9 +95,17 @@
   gap: 20px;
 }
 
+.modal-buttons {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 @media screen and (max-width: 650px) {
   .modal-body {
-    max-height: 400px;
+    max-height: min(72vh, 520px);
   }
 }
 

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.html
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.html
@@ -1,8 +1,13 @@
 <div class="modal-frame">
-  <div class="modal-form">
+  <div
+    class="modal-form"
+    [class.modal-form--small]="size() === 'small'"
+    [class.modal-form--medium]="size() === 'medium'"
+    [class.modal-form--large]="size() === 'large'"
+  >
     <div class="modal-head">
-      <h1>{{ title }}</h1>
-      <span class="close-modal-button" (click)="close()"></span>
+      <h1>{{ title() }}</h1>
+      <button type="button" class="close-modal-button" (click)="close()" aria-label="Close modal"></button>
     </div>
     <div class="modal-body">
       <ng-content select="[modal-body]"></ng-content>
@@ -12,7 +17,7 @@
     </div>
     <div class="modal-buttons">
       <ng-content select="[modal-buttons]"></ng-content>
-      @for (btn of buttons; track btn) {
+      @for (btn of buttons(); track btn.label) {
         <button class="button" (click)="btn.action()">{{ btn.label }}</button>
       }
     </div>

--- a/Frontend/src/app/modals/generic-modal/generic-modal.component.ts
+++ b/Frontend/src/app/modals/generic-modal/generic-modal.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  inject,
+  input,
+  output
+} from '@angular/core';
 
 import { ModalService } from '../../services/modal.service';
 
@@ -7,20 +14,22 @@ export interface GenericModalButton {
   action: () => void;
 }
 
+export type GenericModalSize = 'small' | 'medium' | 'large';
+
 @Component({
   selector: 'app-generic-modal',
-  standalone: true,
   imports: [],
   templateUrl: './generic-modal.component.html',
-  styleUrls: ['./generic-modal.component.css']
+  styleUrls: ['./generic-modal.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class GenericModalComponent {
-  @Input() title: string = '';
-  //@Input() imageUrl: string | null = null;
-  @Input() buttons: GenericModalButton[] = [];
-  @Output() closed = new EventEmitter<void>();
+  readonly title = input('');
+  readonly buttons = input<GenericModalButton[]>([]);
+  readonly size = input<GenericModalSize>('medium');
+  readonly closed = output<void>();
 
-  constructor(private modalService: ModalService) {}
+  private readonly modalService = inject(ModalService);
 
   close() {
     this.closed.emit();

--- a/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.css
+++ b/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.css
@@ -1,6 +1,12 @@
 
+.custom-order-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 #ingredient-list {
-  max-height: 220px;
+  max-height: 420px;
   overflow-y: auto;
   overflow-x: hidden;
 }
@@ -24,7 +30,7 @@
   display: flex;
   justify-content: center;
   gap: 10px;
-  margin-top: 20px;
+  margin-top: 10px;
 }
 
 .order-ingredient:not(.order-ingredient-amount, #no-ingredients) {
@@ -77,6 +83,7 @@
 .order-ingredient-details {
   display: flex;
   flex-direction: column;
+  gap: 6px;
 }
 
 .ingredient-properties {
@@ -108,17 +115,35 @@
 
 /* Container für AI-Generate */
 .ai-generate {
-  display: flex;
-  gap: 0.75rem;
-  padding: 0.5rem 0.75rem;
-  border-radius: 5px;
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(0, 1.2fr);
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
   background-color: var(--ingredient-bg-color);
   color: var(--primary-font-color);
 }
 
-.ai-generate textarea {
+.ai-copy h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1.25rem;
+}
+
+.ai-copy p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.ai-input {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.ai-input textarea {
   flex: 1;
-  height: 1.15rem;
+  height: 2.4rem;
   min-height: 1.2rem;
   max-height: 9rem;
   resize: vertical;
@@ -131,7 +156,7 @@
 }
 
 /* AI-Button */
-.ai-generate button {
+.ai-input button {
   align-self: center;
   padding: 0.45rem 0.7rem;
   border-radius: 5px;
@@ -156,23 +181,27 @@
 }
 
 /* optional kleines Icon vorne dran */
-.ai-generate button::before {
+.ai-input button::before {
   content: "✨";
   font-size: 1rem;
   font-weight: 700;
 }
 
 /* Hover / Active */
-.ai-generate button:hover:not(:disabled) {
+.ai-input button:hover:not(:disabled) {
   background: linear-gradient(135deg, #6366f1, #4f46e5);
   box-shadow: 0 4px 12px rgba(79, 70, 229, 0.4);
 }
 
 @media (max-width: 600px) {
   .ai-generate {
-    flex-direction: column;
+    grid-template-columns: 1fr;
   }
-  .ai-generate button {
+  .ai-input {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .ai-input button {
     justify-content: center;
   }
 }

--- a/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.html
+++ b/Frontend/src/app/modals/order-custom-drink-modal/order-custom-drink-modal.component.html
@@ -1,16 +1,22 @@
-<app-generic-modal title="Configure your own Drink" (closed)="closeModal()">
-    <div id="ingredient-list" modal-body>
+<app-generic-modal title="Configure your own Drink" size="large" (closed)="closeModal()">
+    <div id="ingredient-list" modal-body class="custom-order-body">
       <div class="ai-generate">
-      <textarea id="prompt"
-                [(ngModel)]="prompt"
-                rows="3"
-                placeholder="Describe your perfect drink..."></textarea>
+        <div class="ai-copy">
+          <h3>Create a drink that's uniquely yours</h3>
+          <p>Describe your idea and let the AI suggest a fitting ingredient mix.</p>
+        </div>
+        <div class="ai-input">
+          <textarea id="prompt"
+                    [(ngModel)]="prompt"
+                    rows="3"
+                    placeholder="Describe your perfect drink..."></textarea>
 
-        <button type="button"
-                (click)="aiGenerate()"
-                [disabled]="aiGenerating()">
-          AI-Generate
-        </button>
+          <button type="button"
+                  (click)="aiGenerate()"
+                  [disabled]="aiGenerating()">
+            AI-Generate
+          </button>
+        </div>
       </div>
       @for(ingredient of availableIngredients(); track $index){
         <div class="order-ingredient" [class.selected]="isSelected(ingredient.ingredientName)" (click)="toggleIngredient(ingredient, $event.target!)">

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.css
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.css
@@ -1,17 +1,14 @@
-#drink-overview {
+.order-drink-body {
   display: flex;
-  gap: 20px;
-  margin-bottom: 10px;
+  flex-direction: column;
+  gap: 16px;
 }
 
-@media screen and (max-width: 650px) {
-  #drink-overview {
-    flex-direction: column;
-    max-height: 100%;
-  }
-  .modal-image {
-    align-self: center;
-  }
+.drink-overview {
+  display: grid;
+  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
 }
 
 h1, h3, h4, p:not(.error) {
@@ -19,35 +16,18 @@ h1, h3, h4, p:not(.error) {
   color: var(--heavy-font-color);
 }
 
-h1 {
-  font-size: 2.2rem;
-}
-
-h3 {
-  font-size: 1.5rem;
-}
-
-h4 {
-  font-size: 1.2rem;
-}
-
-p:not(.error) {
-  margin-top: 5px;
-  font-size: 1.1rem;
-  max-width: 400px;
-  overflow-wrap: break-word;
-}
-
 .modal-image {
-  width: 250px;
-  height: 250px;
+  width: 100%;
+  max-width: 280px;
+  aspect-ratio: 1 / 1;
   box-sizing: border-box;
   overflow: hidden;
-  border-radius: 10px;
-  background-color: var(--body-bg);
+  border-radius: 16px;
+  background-color: color-mix(in srgb, var(--body-bg), #ffffff 20%);
   display: flex;
   justify-content: center;
   align-items: center;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
 }
 
 .modal-image img {
@@ -56,59 +36,88 @@ p:not(.error) {
   object-fit: cover;
 }
 
-#modal-ingredient-list {
-  max-height: 265px;
-  min-width: 180px;
-  flex: 1;
+.drink-details {
   display: flex;
   flex-direction: column;
+  gap: 16px;
 }
 
-.checkbox-container label {
-  font-size: 1.2rem;
+.detail-card {
+  background: color-mix(in srgb, var(--popup-bg), #ffffff 10%);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-ul {
-  margin: 10px 0;
+.section-description {
+  font-size: 0.95rem;
+  color: color-mix(in srgb, var(--primary-font-color), #ffffff 30%);
+}
+
+.ingredient-list {
+  margin: 0;
   padding: 0;
   list-style-type: none;
-  font-size: 1.2rem;
+  font-size: 1rem;
   overflow-y: auto;
 }
 
-ul li {
-  margin: 5px 0;
+.ingredient-list li {
+  margin: 6px 0;
 }
 
-ul li::before {
+.ingredient-list li::before {
   margin-right: 0.4rem;
 }
 
-ul li:nth-child(6n+1)::before {
+.ingredient-list li:nth-child(6n+1)::before {
   content: "🍍";
 }
 
-ul li:nth-child(6n+2)::before {
+.ingredient-list li:nth-child(6n+2)::before {
   content: "🥥";
 }
 
-ul li:nth-child(6n+3)::before {
+.ingredient-list li:nth-child(6n+3)::before {
   content: "🌴";
 }
 
-ul li:nth-child(6n+4)::before {
+.ingredient-list li:nth-child(6n+4)::before {
   content: "🐚";
 }
 
-ul li:nth-child(6n+5)::before {
+.ingredient-list li:nth-child(6n+5)::before {
   content: "🐠";
 }
 
-ul li:nth-child(6n+6)::before {
+.ingredient-list li:nth-child(6n+6)::before {
   content: "🦩";
 }
 
 [modal-buttons] {
   display: flex;
   justify-content: end;
+}
+
+.checkbox-container label {
+  font-size: 1rem;
+}
+
+.toppings-card p {
+  font-size: 0.98rem;
+  line-height: 1.5;
+  overflow-wrap: break-word;
+}
+
+@media screen and (max-width: 768px) {
+  .drink-overview {
+    grid-template-columns: 1fr;
+  }
+
+  .modal-image {
+    justify-self: center;
+  }
 }

--- a/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
+++ b/Frontend/src/app/modals/order-drink-modal/order-drink-modal.component.html
@@ -1,30 +1,33 @@
-<app-generic-modal title="{{selectedDrink()?.name}}" (closed)="closeModal()">
-  <div modal-body>
-    <div id="drink-overview">
+<app-generic-modal title="{{selectedDrink()?.name}}" size="medium" (closed)="closeModal()">
+  <div modal-body class="order-drink-body">
+    <div class="drink-overview">
       @if (selectedDrink()?.imgUrl) {
         <div class="modal-image">
           <img [src]="selectedDrink()!.imgUrl" alt="Drink Image" class="drink-image" />
         </div>
       }
-      <div id="modal-ingredient-list">
-        <h3>Ingredients:</h3>
-        <ul>
+      <div class="drink-details">
+        <div class="detail-card">
+          <h3>Ingredients</h3>
+          <p class="section-description">Customize your drink by adding ice if you like it chilled.</p>
+          <ul class="ingredient-list">
           @for (drink of selectedDrink()?.drinkIngredients; track drink) {
             <li>{{drink.amount}}ml {{drink.ingredientName}}</li>
           }
-          <li class="checkbox-container" (click)="containsIce.set(!containsIce())">
-            <input type="checkbox" [(ngModel)]="containsIce" id="containsIce">
+            <li class="checkbox-container" (click)="containsIce.set(!containsIce())">
+              <input type="checkbox" [(ngModel)]="containsIce" id="containsIce">
             <label for="containsIce">Ice</label>
-          </li>
-        </ul>
+            </li>
+          </ul>
+        </div>
+        @if(selectedDrink()?.toppings) {
+          <div class="detail-card toppings-card">
+            <h4>Toppings</h4>
+            <p>{{selectedDrink()!.toppings}}</p>
+          </div>
+        }
       </div>
     </div>
-    @if(selectedDrink()?.toppings) {
-      <div id="toppings">
-        <h4>Toppings:</h4>
-        <p>{{selectedDrink()!.toppings}}</p>
-      </div>
-    }
   </div>
   <div modal-footer>
     <p class="error global-error">{{ globalError() }}</p>

--- a/Frontend/src/app/modals/status-modal/status-modal.component.css
+++ b/Frontend/src/app/modals/status-modal/status-modal.component.css
@@ -1,24 +1,24 @@
-.modal {
-  background: white;
-  padding: 1.5rem;
-  border-radius: 8px;
-  max-width: 400px;
-  margin: auto;
-  box-shadow: 0 0 10px rgba(0,0,0,0.3);
+.status-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
   text-align: center;
 }
-button {
-  margin-top: 1rem;
-  padding: 0.5rem 1rem;
-}
+
 #statusMessage {
-  font-size: 1.7rem;
+  font-size: 1.2rem;
   white-space: pre-line;
+  line-height: 1.5;
+  color: var(--heavy-font-color);
+}
+
+.submit-btn {
+  min-width: 120px;
 }
 .progress-container {
   width: 100%;
   height: 20px;
-  background-color: #ddd;
+  background-color: color-mix(in srgb, #ddd, #ffffff 30%);
   border-radius: 10px;
   overflow: hidden;
   margin-top: 10px;

--- a/Frontend/src/app/modals/status-modal/status-modal.component.html
+++ b/Frontend/src/app/modals/status-modal/status-modal.component.html
@@ -1,5 +1,5 @@
-<app-generic-modal title="Status" (closed)="closeModal()">
-  <div modal-body>
+<app-generic-modal title="Status" size="small" (closed)="closeModal()">
+  <div modal-body class="status-body">
     @if (progressVisible) {
       <div class="progress-container">
         <div class="progress-bar" [style.width.%]="progress"></div>


### PR DESCRIPTION
### Motivation
- Make modal sizes reflect their content (small for status, medium for ordering, large for add/edit/custom drink) to reduce visual noise and improve UX.
- Improve the appearance, hierarchy and responsive behavior of modal content so forms and lists are easier to scan and interact with.
- Increase accessibility and follow Angular/TypeScript best practices for small components (use signals-style `input()`/`output()` and `inject()`).

### Description
- Introduced a `GenericModalSize` (`'small'|'medium'|'large'`) and replaced decorator-based `@Input/@Output` with `input()`/`output()` and `inject()` in `GenericModalComponent`, and enabled `OnPush` change detection.
- Updated `generic-modal` template and CSS to support size classes (`.modal-form--small|--medium|--large`), an accessible close button, improved spacing, max-height handling and responsive layout.
- Reworked `order-drink`, `order-custom-drink` and `drink` (add/edit) modal templates and styles to use clearer section cards, grid/column layouts, refreshed controls (AI-generator area, ingredient lists, image/toppings card) and assigned appropriate modal sizes (`medium`/`large`).
- Made the status modal use the `small` size and refined its typography, progress bar styling and button sizing for concise messages.

### Testing
- Built and served the frontend with `npm run start` and the dev server build completed successfully (application bundles generated).
- Ran headless Playwright interactions that navigated to the app, captured a homepage screenshot, counted UI buttons, opened the custom-order modal via `#order-custom-button`, and captured a custom-modal screenshot; these checks completed successfully and produced artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967d285a1448322a02e9342fab34ee6)